### PR TITLE
Increase reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ make sure the `$GOPATH/bin` path is added to your `$PATH` environment variable. 
 echo $PATH | grep "$GOPATH/bin"
 ```
 
-if nothing shows up, you can the following to your shell config file
+if nothing shows up, you can add the following to your shell config file
 ```bash
 export PATH=$PATH:$GOPATH/bin
-````
+```
 
 add 'ray-x/go.nvim' to your package manager, the dependency is `treesitter` (and optionally, treesitter-objects)
 related binaries will be installed the first time you use it

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ The plugin covers most features required for a gopher.
 
 ## install
 
+make sure the `$GOPATH/bin` path is added to your `$PATH` environment variable. To check this you can run
+```bash
+echo $PATH | grep "$GOPATH/bin"
+```
+
+if nothing shows up, you can the following to your shell config file
+```bash
+export PATH=$PATH:$GOPATH/bin
+````
+
 add 'ray-x/go.nvim' to your package manager, the dependency is `treesitter` (and optionally, treesitter-objects)
 related binaries will be installed the first time you use it
 Add format in your vimrc.

--- a/lua/go.lua
+++ b/lua/go.lua
@@ -15,13 +15,16 @@ function go.setup(cfg)
   vim.cmd('command! Gofmt lua require("go.format").gofmt()')
   vim.cmd('command! Goimport lua require("go.format").goimport()')
 
-  vim.cmd([[command GoBuild :setl makeprg=go\ build | :Gmake]])
-  vim.cmd([[command GoGenerate  :setl makeprg=go\ generate | :Gmake]])
-  vim.cmd([[command GoRun       :setl makeprg=go\ run | :Gmake]])
-  vim.cmd([[command GoTestFunc  :Gmake -run ..]])
 
-  vim.cmd([[command GoTest :setl makeprg=go\ test\ ./... | :Gmake]])
-  vim.cmd([[command GoTestCompile  setl makeprg=go\ build | :Gmake]])
+  local cmds = vim.api.nvim_get_commands({})
+
+  if cmds["GoBuild"]       == nil then vim.cmd([[command GoBuild        :setl makeprg=go\ build | :Gmake]]) end
+  if cmds["GoGenerate"]    == nil then vim.cmd([[command GoGenerate     :setl makeprg=go\ generate | :Gmake]]) end
+  if cmds["GoRun"]         == nil then vim.cmd([[command GoRun          :setl makeprg=go\ run | :Gmake]]) end
+  if cmds["GoTestFunc"]    == nil then vim.cmd([[command GoTestFunc     :Gmake -run ..]]) end
+
+  if cmds["GoTest"]        == nil then vim.cmd([[command GoTest         :setl makeprg=go\ test\ ./... | :Gmake]]) end
+  if cmds["GoTestCompile"] == nil then vim.cmd([[command GoTestCompile  :setl makeprg=go\ build | :Gmake]]) end
 
   vim.cmd([[command! GoAddTest lua require("go.gotests").fun_test()]])
   vim.cmd([[command! GoAddExpTest lua require("go.gotests").exported_test()]])

--- a/lua/go/install.lua
+++ b/lua/go/install.lua
@@ -1,53 +1,42 @@
-local uv = vim.loop
-local gopath = vim.fn.expand("$GOPATH")
-local gobinpath = gopath .. "/bin/"
 local url = {
-  golines = "segmentio/golines",
-  gofumpt = "mvdan/gofumpt",
-  gofumports = "mvdan/gofumpt",
-  gomodifytags = "fatih/gomodifytags",
-  gotsts = "cweill/gotests",
-  iferr = 'koron/iferr',
-  fillstruct = 'davidrjenni/reftools/cmd/fillstruct',
-  fixplurals = 'davidrjenni/reftools/cmd/fixplurals',
-  fillswitch = 'davidrjenni/reftools/cmd/fillswitch',
+  gofumpt      = "mvdan.cc/gofumpt",
+  gofumports   = "mvdan.cc/gofumpt",
+  golines      = "github.com/segmentio/golines",
+  gomodifytags = "github.com/fatih/gomodifytags",
+  gotsts       = "github.com/cweill/gotests",
+  iferr        = 'github.com/koron/iferr',
+  fillstruct   = 'github.com/davidrjenni/reftools/cmd/fillstruct',
+  fixplurals   = 'github.com/davidrjenni/reftools/cmd/fixplurals',
+  fillswitch   = 'github.com/davidrjenni/reftools/cmd/fillswitch',
 }
 
 local function install(bin)
-  local state = uv.fs_stat(gobinpath .. bin)
-  if not state then
+  local state = vim.cmd("!which " .. bin)
+  if string.find(state, "not found") then
     print("installing " .. bin)
-    local u = url[bin]
-    if u == nil then
-      print("command " .. bin .. " not supported, please update install.lua")
-      return
-    end
-    u = 'github.com/' .. u
-    local setup = {
-      "go", "get",
-      u
-    }
-    vim.fn.jobstart(
-      setup,
-      -- setup.args,
-      {
-        on_stdout = function(c, data, name)
-          print(data)
-        end
-      }
-    )
+    go_install(bin)
   end
 end
 
 local function update(bin)
-  local u = url[bin]
+  go_install(bin)  
+end
+
+local function install_all()
+  for key, value in pairs(url) do
+    install(key)
+  end
+end
+
+local function go_install(pkg)
+  local u = url[pkg]
   if u == nil then
-    print("command " .. bin .. " not supported, please update install.lua")
+    print("command " .. pkg .. " not supported, please update install.lua")
     return
   end
 
-  u = 'github.com/' .. u
-  local setup = {"go", "get", "-u", u}
+  u = u .. "@latest"
+  local setup = {"go", "install", u}
 
   vim.fn.jobstart(
     setup,
@@ -57,12 +46,6 @@ local function update(bin)
       end
     }
   )
-end
-
-local function install_all()
-  for key, value in pairs(url) do
-    install(key)
-  end
 end
 
 return {install = install, update = update, install_all = install_all}

--- a/lua/go/install.lua
+++ b/lua/go/install.lua
@@ -1,5 +1,4 @@
 local uv = vim.loop
-
 local DIR_SEP = package.config:sub(1,1)
 
 local url = {
@@ -13,13 +12,6 @@ local url = {
   fixplurals   = 'github.com/davidrjenni/reftools/cmd/fixplurals',
   fillswitch   = 'github.com/davidrjenni/reftools/cmd/fillswitch',
 }
-
-local function run_cmd(cmd)
-    local handle = assert(io.popen(cmd, 'r'))
-    local output = assert(handle:read('*a'))
-    handle:close()
-    return output
-end
 
 local function is_installed(bin)
     local env_path = os.getenv("PATH")

--- a/lua/go/utils.lua
+++ b/lua/go/utils.lua
@@ -4,7 +4,7 @@ util.check_same = function(tbl1, tbl2)
     return false
   end
   for k, v in ipairs(tbl1) do
-    if #v ~= #tbl2[k] or v ~= tbl2[k] then
+    if v ~= tbl2[k] then
       return false
     end
   end

--- a/lua/go/utils.lua
+++ b/lua/go/utils.lua
@@ -1,14 +1,14 @@
 local util = {}
 util.check_same = function(tbl1, tbl2)
   if #tbl1 ~= #tbl2 then
-    return
+    return false
   end
   for k, v in ipairs(tbl1) do
-    if v ~= tbl2[k] then
-      return true
+    if #v ~= #tbl2[k] or v ~= tbl2[k] then
+      return false
     end
   end
-  return false
+  return true
 end
 
 util.copy_array = function(from, to)


### PR DESCRIPTION
While using the plugins I experienced a few reliability issues, so here a pull request to fix them :)

1. Installation: 
         -  `go get` is used to install the binaries, however, `go get` will be deprecated for binary installations, so I changed it to `go install`.  
         - The link for gofumpt has been changed, as it didn't work anymore.
         - Binaries were only looked for in `$GOPATH/bin`, while on some systems commands such as `gofmt` are not installed in that location my default. Therefore I changed binary detection to `which <bin>`, to check for systemwide binaries.
         - Added `$PATH` instructions to the README.md

2. Formatting:
        - the function to detect if code had been changed was inverted. 
        - by default, the format function reads from file instead of from the current buffer. As you are working in the vim buffer, it makes the most sense to me that one would want to format the code that you just wrote, prior to writing to disk, so I changed the buffer flag to true.

3. Commands:
        - There were a few commands that you did not declare with `command!`, which caused issues with reloading. Therefore I added a check in front of those command declarations to only declare them if they are not declared yet, so they don't get overwritten, but also don't throw errors.