### PR TITLE
fix: deprecated dap.stop

### DIFF
--- a/lua/go.lua
+++ b/lua/go.lua
@@ -29,9 +29,9 @@ local dap_config = function()
   vim.cmd([[command! ReplToggle lua require"dap".repl.toggle()]])
   vim.cmd([[command! ReplOpen  lua require"dap".repl.open(), 'split']])
   vim.cmd(
-      [[command! DapRerun require'dap'.disconnect();require'dap'.stop();require'dap'.run_last()]])
+      [[command! DapRerun lua require'dap'.disconnect();require'dap'.close();require'dap'.run_last()]])
 
-  vim.cmd([[command! DapStop require'go.dap'.stop()]])
+  vim.cmd([[command! DapStop lua require'go.dap'.stop()]])
   vim.g.dap_virtual_text = true
 end
 
@@ -88,7 +88,7 @@ function go.setup(cfg)
     vim.cmd([[command! ReplToggle lua require"dap".repl.toggle()]])
     vim.cmd([[command! ReplOpen  lua require"dap".repl.open(), 'split']])
     vim.cmd(
-        [[command! DapRerun require'dap'.disconnect();require'dap'.stop();require'dap'.run_last()]])
+        [[command! DapRerun lua require'dap'.disconnect();require'dap'.close();require'dap'.run_last()]])
 
     vim.cmd([[command! GoDbgStop lua require'go.dap'.stop()]])
 

--- a/lua/go/dap.lua
+++ b/lua/go/dap.lua
@@ -122,7 +122,7 @@ M.stop = function()
 
   vim.cmd([[silent! vunmap p]])
   require'dap'.disconnect()
-  require'dap'.stop();
+  require'dap'.close();
   require"dap".repl.close()
   require("dapui").close()
 end


### PR DESCRIPTION
- fix dap.stop deprecated: https://github.com/mfussenegger/nvim-dap/commit/96d552eea64ec696406e19f1ca29000c4112a8b9
![image](https://user-images.githubusercontent.com/20437334/129438316-bf70c145-8d38-4236-8680-48a18106d04d.png)

- fix DapStop / DapRerun not working
![image](https://user-images.githubusercontent.com/20437334/129438401-457801e3-56f6-4d93-b921-e92c04fdab49.png)
![image](https://user-images.githubusercontent.com/20437334/129438403-09ff209f-7c5c-4412-bc13-e8ed4d4faed4.png)


