### PR TITLE
Make formatting sync during import

### DIFF
--- a/lua/go/format.lua
+++ b/lua/go/format.lua
@@ -80,7 +80,7 @@ end
 M.org_imports = function(wait_ms)
   local codeaction = require('go.lsp').codeaction
   codeaction('', 'source.organizeImports', wait_ms)
-  vim.lsp.buf.formatting()
+  vim.lsp.buf.formatting_sync(nil, wait_ms)
 end
 
 M.goimport = function(...)


### PR DESCRIPTION
With sync formatting, the function can be used in BufWritePre without the buffer ending up modified the save.