### PR TITLE
Support multiple files on GoDebug

### DIFF
--- a/lua/go/dap.lua
+++ b/lua/go/dap.lua
@@ -145,7 +145,7 @@ M.run = function(...)
     dap.configurations.go = {dap_cfg}
     dap.continue()
   else
-    dap_cfg.program = "${file}"
+    dap_cfg.program = sep .. "${relativeFileDirname}"
     dap_cfg.args = args
     dap.configurations.go = {dap_cfg}
     dap.continue()


### PR DESCRIPTION
Running `GoDebug` on `main()` will fail if there are multiple files in `package main` since the other files won't be compiled along with the target file.