### PR TITLE
fix: build tags was missing space

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ require('go').setup({
   dap_debug_keymap = true, -- set keymaps for debugger
   dap_debug_gui = true, -- set to true to enable dap gui, highly recommand
   dap_debug_vt = true, -- set to true to enable dap virtual text
+  build_tags = "tag1,tag2" -- set default build tags
 })
 ```
 

--- a/lua/go/gotest.lua
+++ b/lua/go/gotest.lua
@@ -6,8 +6,12 @@ local ginkgo = require("go.ginkgo")
 local function get_build_tags(args)
   local tags = "-tags"
 
+  local space = [[\ ]]
+  if _GO_NVIM_CFG.run_in_floaterm then
+    space = ' '
+  end
   if _GO_NVIM_CFG.build_tags ~= "" then
-    tags = tags .. [[\ ]] .. _GO_NVIM_CFG.build_tags
+    tags = tags .. space .. _GO_NVIM_CFG.build_tags
   end
 
   for i, value in pairs(args) do
@@ -25,7 +29,7 @@ local function get_build_tags(args)
     tags = ''
   end
 
-  return [[\ ]] .. tags .. [[\ ]], args
+  return space .. tags .. space, args
 end
 
 M.get_build_tags = get_build_tags

--- a/lua/go/gotest.lua
+++ b/lua/go/gotest.lua
@@ -7,7 +7,7 @@ local function get_build_tags(args)
   local tags = "-tags"
 
   if _GO_NVIM_CFG.build_tags ~= "" then
-    tags = tags .. _GO_NVIM_CFG.build_tags
+    tags = tags .. [[\ ]] .. _GO_NVIM_CFG.build_tags
   end
 
   for i, value in pairs(args) do
@@ -25,7 +25,7 @@ local function get_build_tags(args)
     tags = ''
   end
 
-  return tags, args
+  return [[\ ]] .. tags .. [[\ ]], args
 end
 
 M.get_build_tags = get_build_tags


### PR DESCRIPTION
There were missing whitespaces once CMD was built.

This way white spaces are ensured.

Thanks again for this plugin