### PR TITLE
fix: test file function

### DIFF
--- a/lua/go/gotest.lua
+++ b/lua/go/gotest.lua
@@ -242,7 +242,7 @@ M.test_file = function(...)
   -- local testcases = [[sed -n 's/func.*\(Test.*\)(.*/\1/p' | xargs | sed 's/ /\\\|/g']]
   local fpath = vim.fn.expand("%:p")
   -- utils.log(args)
-  local cmd = [[cat ]] .. fpath .. [[| sed -n 's/func.*\(Test.*\)(.*/\1/p' | xargs | sed 's/ /\\|/g']]
+  local cmd = [[cat ]] .. fpath .. [[| sed -n 's/func.*\(Test.*\)(.*/\1/p' | xargs | sed 's/ /\|/g']]
   -- TODO maybe with treesitter or lsp list all functions in current file and regex with Test
   local tests = vim.fn.systemlist(cmd)
   utils.log(cmd, tests)


### PR DESCRIPTION
Test file function wasn't working anymore. It didn't find functions to
test even though the sed found them.

Problem was in the escaping the pipe sign inside go test command. 