### PR TITLE
Fix gotests integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,9 +221,9 @@ Support table based unit test auto generate, parse current function/method name 
 | GoTestFile -tags=yourtag | run test for current folder with `-tags yourtag` option |
 | GoTestPkg                | run test for current package/folder                     |
 | GoTestPkg -tags=yourtag  | run test for current folder with `-tags yourtag` option |
-| GoAddTest                |                                                         |
-| GoAddExpTest             | Add tests for exported funcs                            |
-| GoAddAllTest             | Add tests for all funcs                                 |
+| GoAddTest [-parallel]    | Add test for current func                               |
+| GoAddExpTest [-parallel] | Add tests for exported funcs                            |
+| GoAddAllTest [-parallel] | Add tests for all funcs                                 |
 
 Note: For GoTestXXX
 You can add avaliable arguments e.g. `GoTest -tags=integration ./internal/web -bench=. -count=1 -`
@@ -433,7 +433,7 @@ require('go').setup({
   gofmt = 'gofumpt', --gofmt cmd,
   max_line_len = 120, -- max line length in goline format
   tag_transform = false, -- tag_transfer  check gomodifytags for details
-  test_template = '', -- default to testify if not set; g:go_nvim_tests_template  check gotests for details
+  test_template = '', -- g:go_nvim_tests_template  check gotests for details
   test_template_dir = '', -- default to nil if not set; g:go_nvim_tests_template_dir  check gotests for details
   comment_placeholder = '' ,  -- comment_placeholder your cool placeholder e.g. ﳑ       
   icons = {breakpoint = '🧘', currentpos = '🏃'},

--- a/lua/go.lua
+++ b/lua/go.lua
@@ -128,9 +128,9 @@ function go.setup(cfg)
   -- e.g. GoTestFile unit
   vim.cmd([[command! -nargs=* GoTestFile    lua require('go.gotest').test_file(<f-args>)]])
   vim.cmd([[command! -nargs=* GoTestPkg    lua require('go.gotest').test_package(<f-args>)]])
-  vim.cmd([[command! GoAddTest      lua require("go.gotests").fun_test()]])
-  vim.cmd([[command! GoAddExpTest   lua require("go.gotests").exported_test()]])
-  vim.cmd([[command! GoAddAllTest   lua require("go.gotests").all_test()]])
+  vim.cmd([[command! -nargs=* GoAddTest      lua require("go.gotests").fun_test(<f-args>)]])
+  vim.cmd([[command! -nargs=* GoAddExpTest   lua require("go.gotests").exported_test(<f-args>)]])
+  vim.cmd([[command! -nargs=* GoAddAllTest   lua require("go.gotests").all_test(<f-args>)]])
 
   vim.cmd([[command! GoCodeLenAct   lua require("go.codelens").run_action()]])
   vim.cmd([[command! GoCodeAction   lua require("go.codeaction").run_action()]])

--- a/lua/go/gotests.lua
+++ b/lua/go/gotests.lua
@@ -8,39 +8,39 @@ local utils = require("go.utils")
 local empty = utils.empty
 local run = function(setup)
   print(vim.inspect(setup))
-  local j = vim.fn.jobstart(setup, {
-    on_stdout = function(jobid, data, event)
+   vim.fn.jobstart(setup, {
+    stdout_buffered = true,
+    on_stdout = function(_, data, _)
       print("unit tests generate " .. vim.inspect(data))
-    end,
-    on_stderr = function(_, data, _)
-      print("generate tests finished with message: " .. vim.inspect(setup) .. "error: " .. vim.inspect(data))
     end,
   })
 end
 
 local add_test = function(args)
   require("go.install").install(gotests)
-  if string.len(test_template) > 1 then
+  local gofile = vim.fn.expand("%")
+  table.insert(args, "-w")
+  table.insert(args, gofile)
+  run(args)
+end
+
+local new_gotests_args = function(parallel)
+  local args = { gotests }
+  if parallel then
+    table.insert(args, "-parallel")
+  end
+  if string.len(test_template) > 0 then
     table.insert(args, "-template")
     table.insert(args, test_template)
-    if string.len(test_dir) > 1 then
+    if string.len(test_dir) > 0 then
       table.insert(args, "-template_dir")
       table.insert(args, test_dir)
     end
   end
-  local row, col = unpack(vim.api.nvim_win_get_cursor(0))
-  row, col = row + 1, col + 1
-  local ns = require("go.ts.go").get_func_method_node_at_pos(row, col)
-  if empty(ns) then
-    return
-  end
-
-  utils.log("parnode" .. vim.inspect(ns))
-  run(args)
+  return args
 end
 
 ut.fun_test = function(parallel)
-  parallel = parallel or false
   local row, col = unpack(vim.api.nvim_win_get_cursor(0))
   row, col = row + 1, col + 1
   local ns = require("go.ts.go").get_func_method_node_at_pos(row, col)
@@ -51,31 +51,21 @@ ut.fun_test = function(parallel)
   -- utils.log("parnode" .. vim.inspect(ns))
   local funame = ns.name
   -- local rs, re = ns.dim.s.r, ns.dim.e.r
-  local gofile = vim.fn.expand("%")
-  local args = { gotests, "-w", "-only", funame, gofile }
-  if parallel then
-    table.insert(args, "-parallel")
-  end
+  local args = new_gotests_args(parallel)
+  table.insert(args, "-only")
+  table.insert(args, funame)
   add_test(args)
 end
 
 ut.all_test = function(parallel)
-  parallel = parallel or false
-  local gofile = vim.fn.expand("%")
-  local args = { gotests, "-all", "-w", gofile }
-  if parallel then
-    table.insert(args, "-parallel")
-  end
+  local args = new_gotests_args(parallel)
+  table.insert(args, "-all")
   add_test(args)
 end
 
 ut.exported_test = function(parallel)
-  parallel = parallel or false
-  local gofile = vim.fn.expand("%")
-  local args = { gotests, "-exported", "-w", gofile }
-  if parallel then
-    table.insert(args, "-parallel")
-  end
+  local args = new_gotests_args(parallel)
+  table.insert(args, "-exported")
   add_test(args)
 end
 


### PR DESCRIPTION
GoAddTest, GoAddExpTest and GoAddAllTest affected. Previously they weren't work with templates (go_nvim_test_template
variable) because file paths should be last argument to gotests. Also removed different handling of stdout/stderr because seems that gotests doesn't use stderr or produce any exit code except zero (that probably OK, but not useful for go.nvim).