### PR TITLE
Return cursor to previous cursor position when using `GoGet` and `GoMod`

### DIFF
--- a/lua/go/runner.lua
+++ b/lua/go/runner.lua
@@ -91,6 +91,9 @@ local run = function(cmd, opts)
     end,
   })
 
+  -- Return to previous cursor position
+  api.nvim_command("wincmd p")
+
   -- uv.read_start(stdout, vim.schedule_wrap(on_stdout))
 
   uv.read_start(stderr, function(err, data)


### PR DESCRIPTION
`GoGet` and `GoMod` opens up a new split and move the cursor there. If the cursor isn't moved back to the *.go buffer before the command completes, `utils.restart` will try to spawn gopls in the terminal split buffer, which results in gopls failed to restart properly.

This is a quickfix though, since error will still occur if for example we run `GoGet` on nvim-tree buffer without moving the cursor back to the go file