### PR TITLE
doc: clarify test_runner option

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ require('go').setup({
   dap_debug_vt = true, -- set to true to enable dap virtual text
   build_tags = "tag1,tag2", -- set default build tags
   textobjects = true, -- enable default text jobects through treesittter-text-objects
-  test_runner = 'go', -- one of `go`, `richgo`, `dlv`, `ginkgo`
+  test_runner = 'go', -- one of {`go`, `richgo`, `dlv`, `ginkgo`}
   verbose_tests = true, -- set to add verbose flag to tests
   run_in_floaterm = false, -- set to true to run in float window. :GoTermClose closes the floatterm
                            -- float term recommand if you use richgo/ginkgo with terminal color

--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ require('go').setup({
   dap_debug_vt = true, -- set to true to enable dap virtual text
   build_tags = "tag1,tag2", -- set default build tags
   textobjects = true, -- enable default text jobects through treesittter-text-objects
-  test_runner = 'go', -- richgo, go test, richgo, dlv, ginkgo
+  test_runner = 'go', -- one of `go`, `richgo`, `dlv`, `ginkgo`
   verbose_tests = true, -- set to add verbose flag to tests
   run_in_floaterm = false, -- set to true to run in float window. :GoTermClose closes the floatterm
                            -- float term recommand if you use richgo/ginkgo with terminal color

--- a/doc/go.txt
+++ b/doc/go.txt
@@ -326,7 +326,7 @@ You can setup go.nvim with following options:
   textobjects = true,
   gopls_cmd = nil, --- you can provide gopls path and cmd if it not in PATH, e.g. cmd = {  "/home/ray/.local/nvim/data/lspinstall/go/gopls" }
   build_tags = "", --- you can provide extra build tags for tests or debugger
-  test_runner = "go", -- one of `go`, `richgo`, `dlv`, `ginkgo`
+  test_runner = "go", -- one of {`go`, `richgo`, `dlv`, `ginkgo`}
   verbose_tests = true, -- set to add verbose flag to tests
   run_in_floaterm = false, -- set to true to run in float window.
 }

--- a/doc/go.txt
+++ b/doc/go.txt
@@ -326,7 +326,7 @@ You can setup go.nvim with following options:
   textobjects = true,
   gopls_cmd = nil, --- you can provide gopls path and cmd if it not in PATH, e.g. cmd = {  "/home/ray/.local/nvim/data/lspinstall/go/gopls" }
   build_tags = "", --- you can provide extra build tags for tests or debugger
-  test_runner = "go", -- richgo, go test, richgo, dlv, ginkgo
+  test_runner = "go", -- one of `go`, `richgo`, `dlv`, `ginkgo`
   verbose_tests = true, -- set to add verbose flag to tests
   run_in_floaterm = false, -- set to true to run in float window.
 }

--- a/lua/go.lua
+++ b/lua/go.lua
@@ -59,7 +59,7 @@ _GO_NVIM_CFG = {
   dap_port = 38697, -- can be set to a number or `-1` so go.nvim will pickup a random port
   build_tags = "", --- you can provide extra build tags for tests or debugger
   textobjects = true, -- treesitter binding for text objects
-  test_runner = "go", -- one of `go`, `richgo`, `dlv`, `ginkgo`
+  test_runner = "go", -- one of {`go`, `richgo`, `dlv`, `ginkgo`}
   verbose_tests = true, -- set to add verbose flag to tests
   run_in_floaterm = false, -- set to true to run in float window.
 

--- a/lua/go.lua
+++ b/lua/go.lua
@@ -59,7 +59,7 @@ _GO_NVIM_CFG = {
   dap_port = 38697, -- can be set to a number or `-1` so go.nvim will pickup a random port
   build_tags = "", --- you can provide extra build tags for tests or debugger
   textobjects = true, -- treesitter binding for text objects
-  test_runner = "go", -- richgo, go test, richgo, dlv, ginkgo
+  test_runner = "go", -- one of `go`, `richgo`, `dlv`, `ginkgo`
   verbose_tests = true, -- set to add verbose flag to tests
   run_in_floaterm = false, -- set to true to run in float window.
 


### PR DESCRIPTION
Clarify the doc of setup option `test_runner`
1. Remove duplicate item `richgo`.
2. Change `go test` to `go` for accuracy.