### PR TITLE
fix(code_actions): Remove now deprecated telescope_code_actions()

### DIFF
--- a/lua/go/lsp.lua
+++ b/lua/go/lsp.lua
@@ -50,7 +50,7 @@ local on_attach = function(client, bufnr)
     buf_set_keymap("n", "<space>wl", "<cmd>lua print(vim.inspect(vim.lsp.buf.list_workspace_folders()))<CR>", opts)
     buf_set_keymap("n", "<space>D", "<cmd>lua vim.lsp.buf.type_definition()<CR>", opts)
     buf_set_keymap("n", "<space>rn", "<cmd>lua vim.lsp.buf.rename()<CR>", opts)
-    buf_set_keymap("n", "<space>ca", '<cmd>lua require"go.lsp".telescope_code_actions()<CR>', opts)
+    buf_set_keymap("n", "<space>ca", "<cmd>lua vim.lsp.buf.code_action()<CR>", opts)
     buf_set_keymap("n", "gr", "<cmd>lua vim.lsp.buf.references()<CR>", opts)
     buf_set_keymap("n", "<space>e", "<cmd>lua vim.lsp.diagnostic.show_line_diagnostics()<CR>", opts)
     buf_set_keymap("n", "[d", "<cmd>lua vim.lsp.diagnostic.goto_prev()<CR>", opts)
@@ -198,22 +198,6 @@ M.codeaction = function(action, only, wait_ms)
         end
       end
     end
-  end
-end
-
-function M.telescope_code_actions()
-  local ok, _ = utils.load_plugin("telescope.nvim", "telescope.builtin")
-  if ok then
-    local themes = require("telescope.themes")
-    local opts = themes.get_dropdown({
-      winblend = 10,
-      border = true,
-      previewer = false,
-      shorten_path = false,
-    })
-    require("telescope.builtin").lsp_code_actions(opts)
-  else
-    vim.lsp.buf.code_action()
   end
 end
 


### PR DESCRIPTION
- Removes `telescope_code_actions()` function.
- Sets associated keybinding to `vim.lsp.buf.code_action`

First of all, love the plugin, thanks for creating such a great tool.
I am submitting this PR as I recently lost code actions functionality with go.nvim and was presented with:
![2022-05-27_15-51](https://user-images.githubusercontent.com/37380474/170717537-f6faf295-9b7b-4aa1-b04e-b76feff3e2ef.png) 

A bit of googling later I found out that it appears the `code actions` builtin has been removed from telescope. More on this [here](https://github.com/nvim-telescope/telescope.nvim/pull/1866) and [here](https://github.com/nvim-telescope/telescope.nvim/issues/1470#issuecomment-1106707726). 

For now using the `vim.lsp.buf.code_action` command seems to be the way to go. In order to get some nice UI component integration back  [telescope-ui-select](https://github.com/nvim-telescope/telescope-ui-select.nvim) and [dressing.nvim](https://github.com/stevearc/dressing.nvim) would be options. The latter of which would be an extra dependency.

If you want to integrate one of these in the future, I could take a whack at it. 