### PR TITLE
Fix/test file

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ require('go').setup({
   dap_debug_vt = true, -- set to true to enable dap virtual text
   build_tags = "tag1,tag2", -- set default build tags
   textobjects = true, -- enable default text jobects through treesittter-text-objects
-  test_runner = 'go', -- one of {`go`, `richgo`, `dlv`, `ginkgo`}
+  test_runner = 'go', -- one of {`go`, `richgo`, `ginkgo`}
   verbose_tests = true, -- set to add verbose flag to tests
   run_in_floaterm = false, -- set to true to run in float window. :GoTermClose closes the floatterm
                            -- float term recommand if you use richgo/ginkgo with terminal color

--- a/doc/go.txt
+++ b/doc/go.txt
@@ -329,7 +329,7 @@ You can setup go.nvim with following options:
   textobjects = true,
   gopls_cmd = nil, --- you can provide gopls path and cmd if it not in PATH, e.g. cmd = {  "/home/ray/.local/nvim/data/lspinstall/go/gopls" }
   build_tags = "", --- you can provide extra build tags for tests or debugger
-  test_runner = "go", -- one of {`go`, `richgo`, `dlv`, `ginkgo`}
+  test_runner = "go", -- one of {`go`, `richgo`, `ginkgo`}
   verbose_tests = true, -- set to add verbose flag to tests
   run_in_floaterm = false, -- set to true to run in float window.
 }

--- a/lua/go/gotest.lua
+++ b/lua/go/gotest.lua
@@ -407,7 +407,7 @@ M.test_file = function(...)
   end
   table.insert(cmd_args, "-run")
 
-  table.insert(cmd_args, "'" .. tests .. "'") -- shell script | is a pipe
+  table.insert(cmd_args, tests)
   table.insert(cmd_args, relpath)
 
   if run_in_floaterm then

--- a/lua/tests/go_test_spec.lua
+++ b/lua/tests/go_test_spec.lua
@@ -61,7 +61,7 @@ describe("should run test file", function()
     vim.fn.setpos(".", { 0, 5, 11, 0 })
     local cmd = require("go.gotest").test_file()
 
-    eq({ "go", "test", "-v", "-run", "'Test_branch|TestBranch'", "./lua/tests/fixtures/coverage" }, cmd)
+    eq({ "go", "test", "-v", "./lua/tests/fixtures/coverage" }, cmd)
   end)
 end)
 
@@ -84,7 +84,7 @@ describe("should run test file with flags", function()
     vim.fn.setpos(".", { 0, 5, 11, 0 })
     local cmd = require("go.gotest").test_file("-t", "tag1")
 
-    eq({ "go", "test", "-tags=tag1", "-v", "-run", "'Test_branch|TestBranch'", "./lua/tests/fixtures/coverage" }, cmd)
+    eq({ "go", "test", "-tags=tag1", "-v", "./lua/tests/fixtures/coverage" }, cmd)
   end)
 end)
 

--- a/samplevimrc.vim
+++ b/samplevimrc.vim
@@ -40,7 +40,7 @@ require('go').setup({
   dap_debug_gui = true, -- set to true to enable dap gui, highly recommand
   dap_debug_vt = true, -- set to true to enable dap virtual text
 
-  test_runner = 'richgo', -- richgo, go test, richgo, dlv, ginkgo
+  test_runner = 'richgo', -- richgo, go test, richgo, ginkgo
   verbose_tests = true, -- set to add verbose flag to tests
   run_in_floaterm = true -- set to true to run in float window.
 })


### PR DESCRIPTION
This pull requests includes two commits, you can discard the second one if you wish to.

The first commit fixes regex for test file, once the single quotes were added the regex matching didn't work anymore.

In the second commit, I've simplified the logic. Since go is smart enough that it tests only funcs starting with Test, we basically don't even need the regex. I've removed it and left the relative path only.

I've also removed the dlv option for testing files, since I couldn't find a way to get it working using GoTestFile.

As I said you can discard the second one if you think it shouldn't be this way.

As always, thanks for this plugin