### PR TITLE
fix(setup): getenv vim.NIL check

### DIFF
--- a/lua/go.lua
+++ b/lua/go.lua
@@ -259,7 +259,7 @@ function go.setup(cfg)
   -- TODO remove in future
   gobin = vfn.getenv("GOBIN")
   if gobin == vim.NIL then
-    gobin = ""
+    return
   end
   require('go.env').append('PATH', gobin)
 end


### PR DESCRIPTION
https://github.com/ray-x/go.nvim/commit/36a33ad5b0638ae487b6ee44b10a722a550f34d6 introduced an error when calling `require("go").setup {}` and environment variable **GOBIN** is empty. 

This is caused by this code: https://github.com/ray-x/go.nvim/blob/36a33ad5b0638ae487b6ee44b10a722a550f34d6/lua/go.lua#L257-L258
vim.fn.getenv() would return vim.NIL and thus can't be used for concatenating.

This PR adds a check for vim.NIL and sets gobin to an empty string.