### PR TITLE
fix(dap): don't close empty stdout stderr handle Add nil check to closure of stdout stderr handle

### DIFF
--- a/lua/go/dap.lua
+++ b/lua/go/dap.lua
@@ -349,9 +349,9 @@ M.run = function(...)
         end)
       end
 
-      stdout:close()
-      stderr:close()
-      handle:close()
+      _ = stdout and stdout:close()
+      _ = stderr and stderr:close()
+      _ = handle and handle:close()
       stdout = nil
       stderr = nil
       handle = nil


### PR DESCRIPTION
Calling `c` repeatedly caused the state of stdout stderr and handle to drift, resulting in the closure of nil.

Example error:
```
...share/nvim/site/pack/packer/start/go.nvim/lua/go/dap.lua:352: attempt to index upvalue 'stdout' (a nil value)
stack traceback:
        ...share/nvim/site/pack/packer/start/go.nvim/lua/go/dap.lua:352: in function <...share/nvim/site/pack/packer/start/go.nvim/lua/go/dap.lua:341>
        [C]: in function 'handler'
        /usr/share/nvim/runtime/lua/vim/treesitter/query.lua:434: in function 'match_preds'
        /usr/share/nvim/runtime/lua/vim/treesitter/query.lua:519: in function 'iter'
        /usr/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:287: in function 'fn'
        /usr/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:194: in function 'for_each_tree'
        /usr/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:261: in function 'on_line_impl'
        /usr/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:320: in function </usr/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:314>
```