### PR TITLE
synchronous goimports

### DIFF
--- a/lua/go/format.lua
+++ b/lua/go/format.lua
@@ -138,11 +138,11 @@ M.org_imports = function(wait_ms)
   local codeaction = require("go.lsp").codeaction
   codeaction("", "source.organizeImports", wait_ms)
   if _GO_NVIM_CFG.lsp_fmt_async then
-	  vim.defer_fn(function()
-		vim.lsp.buf.format({ async = _GO_NVIM_CFG.lsp_fmt_async })
-	  end, 100)
+    vim.defer_fn(function()
+      vim.lsp.buf.format({ async = true })
+    end, 100)
   else
-		vim.lsp.buf.format({ async = _GO_NVIM_CFG.lsp_fmt_async })
+    vim.lsp.buf.format({ async = false })
   end
 end
 

--- a/lua/go/format.lua
+++ b/lua/go/format.lua
@@ -142,7 +142,7 @@ M.org_imports = function(wait_ms)
 		vim.lsp.buf.format({ async = _GO_NVIM_CFG.lsp_fmt_async })
 	  end, 100)
   else
-		vim.lsp.buf.formatting_sync()
+		vim.lsp.buf.format({ async = _GO_NVIM_CFG.lsp_fmt_async })
   end
 end
 

--- a/lua/go/format.lua
+++ b/lua/go/format.lua
@@ -137,9 +137,13 @@ end
 M.org_imports = function(wait_ms)
   local codeaction = require("go.lsp").codeaction
   codeaction("", "source.organizeImports", wait_ms)
-  vim.defer_fn(function()
-    vim.lsp.buf.format({ async = _GO_NVIM_CFG.lsp_fmt_async })
-  end, 100)
+  if _GO_NVIM_CFG.lsp_fmt_async then
+	  vim.defer_fn(function()
+		vim.lsp.buf.format({ async = _GO_NVIM_CFG.lsp_fmt_async })
+	  end, 100)
+  else
+		vim.lsp.buf.formatting_sync()
+  end
 end
 
 M.goimport = function(...)

--- a/lua/go/lsp.lua
+++ b/lua/go/lsp.lua
@@ -8,7 +8,13 @@ end
 
 if vim.lsp.buf.format == nil then
   -- neovim < 0.7 only
-  vim.lsp.buf.format = vim.lsp.buf.formatting
+  vim.lsp.buf.format = function(options)
+	if options.async then
+	  vim.lsp.buf.formatting()
+    else
+	  vim.lsp.buf.formatting_sync()
+    end
+  end
 end
 
 local codelens_enabled = false

--- a/lua/go/lsp.lua
+++ b/lua/go/lsp.lua
@@ -9,11 +9,10 @@ end
 if vim.lsp.buf.format == nil then
   -- neovim < 0.7 only
   vim.lsp.buf.format = function(options)
-	if options.async then
-	  vim.lsp.buf.formatting()
-    else
-	  vim.lsp.buf.formatting_sync()
-    end
+  if options.async then
+    vim.lsp.buf.formatting()
+  else
+    vim.lsp.buf.formatting_sync()
   end
 end
 


### PR DESCRIPTION
When saving file while using auto saving (from README).
```
vim.api.nvim_exec([[ autocmd BufWritePre *.go :silent! lua require('go.format').goimport() ]], false)
```
The code is formatted, but not saved. (Formatting is executed after the file is saved)
Thie PR causes that goimports to be synchronous. (depending on lsp_fmt_async)