### PR TITLE
Pass build tags when running tests with dlv

### DIFF
--- a/lua/go/gotest.lua
+++ b/lua/go/gotest.lua
@@ -366,7 +366,11 @@ M.test_func = function(...)
   table.insert(cmd, fpath)
 
   if test_runner == "dlv" then
-    cmd = { "dlv", "test", fpath, "--", "-test.run", "^" .. ns.name }
+    if tags and #tags>0 then
+      cmd = { "dlv", "test", fpath, "--build-flags", tags, "--", "-test.run", "^" .. ns.name }
+    else
+      cmd = { "dlv", "test", fpath, "--", "-test.run", "^" .. ns.name }
+    end
     local term = require("go.term").run
     term({ cmd = cmd, autoclose = false })
     return


### PR DESCRIPTION
dlv does provide a flag for passing build tags, although it is diferent
than the build tag flag for the go command line utility. This commit
adds that syntax to pass flags to dlv as specified.