### PR TITLE
fix test_func

### DIFF
--- a/lua/go/gotest.lua
+++ b/lua/go/gotest.lua
@@ -83,6 +83,15 @@ M.get_build_tags = function(args, tbl)
 
 end
 
+local function get_test_path()
+  local path = vim.fn.expand("%:p:h")
+  local relative_path = vim.fn.fnamemodify(path, ":.")
+  if path == relative_path then
+    return path
+  end
+  return "." .. sep .. relative_path
+end
+
 local function richgo(cmd)
   if cmd[1] == "go" and vfn.executable("richgo") == 1 then
     cmd[1] = "richgo"
@@ -272,7 +281,7 @@ end
 M.test_package = function(...)
   local args = { ... }
   log(args)
-  local fpath = "." .. sep .. vfn.fnamemodify(vfn.expand("%:h"), ":.") .. sep .. "..."
+  local fpath = get_test_path() .. sep .. "..."
   utils.log("fpath: " .. fpath)
   return run_test(fpath, args)
 end
@@ -362,7 +371,7 @@ M.test_func = function(...)
     table.insert(cmd, [['^]] .. ns.name .. [[$']])
   end
 
-  local fpath = vfn.expand("%:h")
+  local fpath = get_test_path()
   table.insert(cmd, fpath)
 
   if test_runner == "dlv" then

--- a/lua/go/gotest.lua
+++ b/lua/go/gotest.lua
@@ -362,7 +362,7 @@ M.test_func = function(...)
     table.insert(cmd, [['^]] .. ns.name .. [[$']])
   end
 
-  local fpath = "." .. sep .. vfn.fnamemodify(vfn.expand("%:h"), ":.")
+  local fpath = vfn.expand("%:h")
   table.insert(cmd, fpath)
 
   if test_runner == "dlv" then


### PR DESCRIPTION
# 运行环境
```shell
$ uname -mrsv
Darwin 21.6.0 Darwin Kernel Version 21.6.0: Wed Aug 10 14:28:35 PDT 2022; root:xnu-8020.141.5~2/RELEASE_ARM64_T8101 arm64
```

```shell
$ nvim --version
NVIM v0.7.2
Build type: Release
LuaJIT 2.1.0-beta3
```

```shell
$ cd ~/.local/share/nvim/site/pack/packer/start/go.nvim && git log
commit 6ef00998e2003db399df8251da1c30fd20eada43 (HEAD -> master, origin/master, origin/HEAD)
Author: ray-x <rayx.cn@gmail.com>
Date:   Fri Sep 2 23:52:34 2022 +1000

    keymap for range code action
```

```shell
$ pwd
/Users/ruifeng/Documents/Obsidian-code/Go-learning/语言基础/005-learn-go-with-tests/003-hello-world
```

```
$ ls
go.mod  main.go main_test.go
```

```shell
$ cat main.go
package main

func Get5() int {
  return 5
}

func main() {
}
```

```shell
$ cat main_test.go
package main

import "testing"

func TestGet5(t *testing.T) {
	tests := []struct {
		name string
		want int
	}{
		// TODO: Add test cases.
    {name: "success: ", want: 5},
    {name: "fail: ", want: 4},
	}
	for _, tt := range tests {
		t.Run(tt.name, func(t *testing.T) {
			if got := Get5(); got != tt.want {
				t.Errorf("Get5() = %v, want %v", got, tt.want)
			}
		})
	}
}
```

go.nvim 的配置如下：
```lua
require('go').setup({

  disable_defaults = false, -- true|false when true set false to all boolean settings and replace all table settings with {}
  go='go', -- go command, can be go[default] or go1.18beta1
  goimport='gopls', -- goimport command, can be gopls[default] or goimport
  fillstruct = 'gopls', -- can be nil (use fillstruct, slower) and gopls
  gofmt = 'gofumpt', --gofmt cmd,
  max_line_len = 128, -- max line length in golines format, Target maximum line length for golines
  tag_transform = false, -- can be transform option("snakecase", "camelcase", etc) check gomodifytags for details and more options
  gotests_template = "", -- sets gotests -template parameter (check gotests for details)
  gotests_template_dir = "", -- sets gotests -template_dir parameter (check gotests for details)
  comment_placeholder = '' ,  -- comment_placeholder your cool placeholder e.g. ﳑ       
  icons = {breakpoint = '🧘', currentpos = '🏃'},  -- setup to `false` to disable icons setup
  verbose = false,  -- output loginf in messages
  lsp_cfg = false, -- true: use non-default gopls setup specified in go/lsp.lua
                   -- false: do nothing
                   -- if lsp_cfg is a table, merge table with with non-default gopls setup in go/lsp.lua, e.g.
                   --   lsp_cfg = {settings={gopls={matcher='CaseInsensitive', ['local'] = 'your_local_module_path', gofumpt = true }}}
  lsp_gofumpt = false, -- true: set default gofmt in gopls format to gofumpt
  lsp_on_attach = nil, -- nil: use on_attach function defined in go/lsp.lua,
                       --      when lsp_cfg is true
                       -- if lsp_on_attach is a function: use this function as on_attach function for gopls
  lsp_keymaps = true, -- set to false to disable gopls/lsp keymap
  lsp_codelens = true, -- set to false to disable codelens, true by default, you can use a function
  -- function(bufnr)
  --    vim.api.nvim_buf_set_keymap(bufnr, "n", "<space>F", "<cmd>lua vim.lsp.buf.formatting()<CR>", {noremap=true, silent=true})
  -- end
  -- to setup a table of codelens
  lsp_diag_hdlr = true, -- hook lsp diag handler
  -- virtual text setup
  lsp_diag_virtual_text = { space = 0, prefix = "" },
  lsp_diag_signs = true,
  lsp_diag_update_in_insert = false,
  lsp_document_formatting = true,
  -- set to true: use gopls to format
  -- false if you want to use other formatter tool(e.g. efm, nulls)
 lsp_inlay_hints = {
    enable = true,
    -- Only show inlay hints for the current line
    only_current_line = false,
    -- Event which triggers a refersh of the inlay hints.
    -- You can make this "CursorMoved" or "CursorMoved,CursorMovedI" but
    -- not that this may cause higher CPU usage.
    -- This option is only respected when only_current_line and
    -- autoSetHints both are true.
    only_current_line_autocmd = "CursorHold",
    -- whether to show variable name before type hints with the inlay hints or not
    -- default: false
    show_variable_name = true,
    -- prefix for parameter hints
    parameter_hints_prefix = " ",
    show_parameter_hints = true,
    -- prefix for all the other hints (type, chaining)
    other_hints_prefix = "=> ",
    -- whether to align to the lenght of the longest line in the file
    max_len_align = false,
    -- padding from the left if max_len_align is true
    max_len_align_padding = 1,
    -- whether to align to the extreme right or not
    right_align = false,
    -- padding from the right if right_align is true
    right_align_padding = 6,
    -- The color of the hints
    highlight = "Comment",
  },
  gopls_cmd = nil, -- if you need to specify gopls path and cmd, e.g {"/home/user/lsp/gopls", "-logfile","/var/log/gopls.log" }
  gopls_remote_auto = true, -- add -remote=auto to gopls
  gocoverage_sign = "█",
  sign_priority = 5, -- change to a higher number to override other signs
  dap_debug = true, -- set to false to disable dap
  dap_debug_keymap = true, -- true: use keymap for debugger defined in go/dap.lua
                           -- false: do not use keymap in go/dap.lua.  you must define your own.
                           -- windows: use visual studio keymap
  dap_debug_gui = true, -- set to true to enable dap gui, highly recommand
  dap_debug_vt = true, -- set to true to enable dap virtual text
  build_tags = "tag1,tag2", -- set default build tags
  textobjects = true, -- enable default text jobects through treesittter-text-objects
  test_runner = 'richgo', -- one of {`go`, `richgo`, `dlv`, `ginkgo`}
  verbose_tests = true, -- set to add verbose flag to tests
  run_in_floaterm = false, -- set to true to run in float window. :GoTermClose closes the floatterm
                           -- float term recommand if you use richgo/ginkgo with terminal color

  trouble = false, -- true: use trouble to open quickfix
  test_efm = false, -- errorfomat for quickfix, default mix mode, set to true will be efm only
  luasnip = false, -- enable included luasnip snippets. you can also disable while add lua/snips folder to luasnip load
  --  Do not enable this if you already added the path, that will duplicate the entries
})
```

# 错误描述
我在以下情况会遇到错误：
1. 在路径 `/Users/ruifeng/Documents/Obsidian-code/Go-learning/语言基础/005-learn-go-with-tests/003-hello-world` 下执行命令 `nvim` 打开 nvim。
2. 通过 `nvim-tree` 打开文件 `main_test.go`。
3. 移动光标到 TestGet5，执行 `:GoTestFunc` 无法进行正常测试 —— 测试信息没有输出。nvim 输出消息：`richgo test -tags=tag1,tag2 -run '^TestGet5$' .//Users/ruifeng/Documents/Obsidian-code/Go-learning/语言基础/005-learn-go-with-tests/003-hello-world exited with code: 1 faile`。

# 解决思路
1. 根据 nvim 的输出消息，测试命令中的路径为 `.//Users/ruifeng/Documents/Obsidian-code/Go-learning/语言基础/005-learn-go-with-tests/003-hello-world` 不太对，应该为 `./Users/ruifeng/Documents/Obsidian-code/Go-learning/语言基础/005-learn-go-with-tests/003-hello-world` 或 `.`。
2. 找到 go-nvim 中与 GoTestFunc 路径有关的部分进行修改（即本次提交中的修改）。
3. 再次按照 错误描述 中的步骤执行，测试信息可以正常输出：
    ```
    || --- FAIL: TestGet5 (0.00s)
    ||     --- FAIL: TestGet5/fail:_ (0.00s)
    main_test.go|17| Get5() = 5, want 4
    || FAIL	003-hello-world	0.671s
    ```
    nvim 输出消息：`richgo test -tags=tag1,tag2 -run '^TestGet5$' /Users/ruifeng/Documents/Obsidian-code/Go-learning/语言基础/005-learn-go-with-tests/003-hello-world exited with code: 1 faile`。

# 其他
- 可能我的解决方法不对，但是上面的问题确实存在，希望大佬有时间修一下。
- 感觉 fpath 表示的是当前文件所在路径，而 `vfn.expand("%:h")` 得到的就是当前文件所在路径，为什么还要 ` "." .. sep .. vfn.fnamemodify(vfn.expand("%:h"), ":.")` 这样呢？
- 新手愚见，有什么不对的地方还望大佬海涵并指出。
- 感谢大佬为社区做出的贡献。