### PR TITLE
Add an option for single package coverage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ first run of `GoFmt` may fail. It is recommended to run `GoInstallBinaries` to i
 | GoGet {package_url}                           | go get package_url and restart gopls. Note1                              |
 | GoVet                                         | go vet                                                                   |
 | GoCoverage                                    | go test -coverprofile                                                    |
+| GoCoverage -p                                 | go test -coverprofile (only tests package for current buffer)            |
 | GoCoverage -f coverage_file_name              | load coverage file                                                       |
 | GoCoverage {flags}                            | -t : toggle, -r: remove signs, -R remove sings from all files, -m show metrics|
 | GoTermClose                                   | `closes the floating term`                                               |

--- a/lua/go/coverage.lua
+++ b/lua/go/coverage.lua
@@ -349,7 +349,21 @@ M.run = function(...)
     log(args2)
     cmd = vim.list_extend(cmd, args2)
   else
-    local argsstr = '.' .. utils.sep() .. '...'
+	local argsstr
+
+	if load == '-p' then 
+	  local pkg = require("go.package").pkg_from_path(nil, vim.api.nvim_get_current_buf())
+	  if vfn.empty(pkg) == 1 then
+	    util.log("No package found in current directory.")
+	    return nil
+	  end
+	  
+	  argsstr = pkg[1]
+    else 
+	  argsstr = '.' .. utils.sep() .. '...'
+	end
+
+
     table.insert(cmd, argsstr)
   end
 


### PR DESCRIPTION
The current GoCoverage command runs tests on the entire repository, which, when running on a project that takes e.g. a minute to complete testing, is quite slow. Vscode-go and Vim-go, when running their equivalent commands, will run tests on the current buffer's package, thus returning visual results _much_ faster. (In my use case, some packages may take milliseconds to test while others may take several seconds, but never the full minute that running this command as-is would require.)

The PR adds a `-p` option to the coverage command that will get the package for the current buffer and only run tests for it, greatly increasing iteration time. There's only one caveat with which I require help - Vim seems to give out `Missed option for -p` even though after logging this error everything runs fine, where could I add the new option so we don't get these errors?

Thanks!