### PR TITLE
fix(gotest): wrong order of test binary args

### DIFF
--- a/lua/go/asyncmake.lua
+++ b/lua/go/asyncmake.lua
@@ -172,11 +172,6 @@ function M.make(...)
       log("run test", efm)
       table.insert(cmd, "-run")
     end
-    if optarg["a"] then
-      log("extra args", optarg["a"])
-      table.insert(cmd, "-args")
-      table.insert(cmd, optarg["a"])
-    end
     if not bench and compile_test then
       table.insert(cmd, "-c")
     end
@@ -186,6 +181,11 @@ function M.make(...)
     cmd = vim.list_extend(cmd, args)
   elseif args and #args > 0 then
     cmd = vim.list_extend(cmd, reminder)
+  end
+
+  if optarg["a"] then
+    table.insert(cmd, "-args")
+    table.insert(cmd, optarg["a"])
   end
 
   local function handle_color(line)
@@ -273,7 +273,7 @@ function M.make(...)
       end
       if next(errorlines) ~= nil and runner == "golangci-lint" then
         efm =
-          [[level=%tarning\ msg="%m:\ [%f:%l:%c:\ %.%#]",level=%tarning\ msg="%m",level=%trror\ msg="%m:\ [%f:%l:%c:\ %.%#]",level=%trror\ msg="%m",%f:%l:%c:\ %m,%f:%l:\ %m,%f:%l\ %m]]
+        [[level=%tarning\ msg="%m:\ [%f:%l:%c:\ %.%#]",level=%tarning\ msg="%m",level=%trror\ msg="%m:\ [%f:%l:%c:\ %.%#]",level=%trror\ msg="%m",%f:%l:%c:\ %m,%f:%l:\ %m,%f:%l\ %m]]
       end
     end
 

--- a/lua/tests/go_test_spec.lua
+++ b/lua/tests/go_test_spec.lua
@@ -42,6 +42,24 @@ describe("should run func test", function()
 
     eq({ "go", "test", "-v", "-run", [['^Test_branch$']], "./lua/tests/fixtures/coverage" }, cmd)
   end)
+  it("should test function with additional args to test binary", function()
+    --
+    -- go.nvim may not auto loaded
+    vim.cmd([[packadd go.nvim]])
+
+    local path = cur_dir .. "/lua/tests/fixtures/coverage/branch_test.go" -- %:p:h ? %:p
+    require("go").setup({
+      trace = true,
+      lsp_cfg = true,
+      log_path = vim.fn.expand("$HOME") .. "/tmp/gonvim.log",
+      test_runner = "go",
+    })
+    vim.cmd("silent exe 'e " .. path .. "'")
+    vim.fn.setpos(".", { 0, 5, 11, 0 })
+    local cmd = require("go.gotest").test_func("-a", "mock=true")
+
+    eq({ "go", "test", "-v", "-run", [['^Test_branch$']], "./lua/tests/fixtures/coverage", "-args", "mock=true" }, cmd)
+  end)
 end)
 
 describe("should run test file", function()


### PR DESCRIPTION
Hi @ray-x , thanks for this commit https://github.com/ray-x/go.nvim/commit/e9d1c6c02159965f9f1bbd5699ddbdb9a4f92088. for this issue https://github.com/ray-x/go.nvim/issues/229, 
however, the previous  would create insert the args after the ```-run``` resulted in error.

this PR is trying to fix that. and is my first time writing lua, do let me know if is ok
i.e 
``` require("go.gotest").test_func("-a", "mock=true")``` would result in
``` go test -tags=tag1,tag2 -v -run -args mock=true '^TestXXXX$' ./XXX'```

expected is 
``` go test -tags=tag1,tag2 -v -run '^TestXXXX$' ./XXX -args mock=true '```