### PR TITLE
fix: latest treesitter expects ;; extends

### DIFF
--- a/after/queries/go/injections.scm
+++ b/after/queries/go/injections.scm
@@ -1,3 +1,4 @@
+;; extends
 (
  (const_spec
   name: (identifier) @_id

--- a/after/queries/go/locals.scm
+++ b/after/queries/go/locals.scm
@@ -1,3 +1,4 @@
+;; extends
 (field_declaration
   name: (field_identifier) @definition.field)
 


### PR DESCRIPTION
If this comment is not present it will overwrite all existing queries with the content of the respective file.
Also move files from queries/go -> after/queries/go to ensure they are loaded after e.g. nvim-treesitter queries.

This is especially visible with `locals.scm` as for me it did not longer auto-highlight other occurrences of the same variable until I added `;; extends` at the top.