### PR TITLE
utils.lua remove debugging expression

### DIFF
--- a/lua/go/utils.lua
+++ b/lua/go/utils.lua
@@ -846,6 +846,4 @@ util.extract_filepath = function(msg)
   end
 end
 
-print(util.extract_filepath([[/home/ray/go/src/github/sample/app/driver.go:342 +0x19e5]]))
-
 return util


### PR DESCRIPTION
I believe this might have been committed on accident.

In addition, there seems to be a separate issue. I get this output on startup:
`WARN: find failed find ./ -type f -name /home/ray/go/src/github/sample/app/driver.go{ "FIND: Invalid switch\r" }`
Which leads me to believe somewhere the script is shelling out to `find`.
I'm on Windows where `find.exe` is not the POSIX variant, so any function that depends on it will likely fail.