### PR TITLE
fix E5560 wrap vim api calls inside luv loop

### DIFF
--- a/lua/go/null_ls.lua
+++ b/lua/go/null_ls.lua
@@ -160,7 +160,10 @@ return {
           if not success then
             -- can be noisy for things that run often (e.g. diagnostics), but can
             -- be useful for things that run on demand (e.g. formatting)
-            vim.notify('go test failed: ' .. tostring(stderr), vim.lsp.log_levels.WARN)
+            vim.schedule_wrap(function()
+                vim.notify('go test failed: ' .. tostring(stderr), vim.lsp.log_levels.WARN)
+            end)
+
           end
           return true
         end,


### PR DESCRIPTION
```
Error executing luv callback:
vim/_editor.lua:0: E5560: nvim_echo must not be called in a lua loop callback
stack traceback:
        [C]: in function 'nvim_echo'
        vim/_editor.lua: in function 'notify'
        ...are/nvim/site/pack/packer/opt/go.nvim/lua/go/null_ls.lua:164: in function 'check_exit_code'
        ...m/site/pack/packer/opt/null-ls.nvim/lua/null-ls/loop.lua:122: in function <...m/site/pack/packer/opt/null-ls.nvim/lua/null-ls/loop.lua:101>
```

