### PR TITLE
fix: make the template and template dir parameters independent.

### DIFF
--- a/lua/go/gotests.lua
+++ b/lua/go/gotests.lua
@@ -32,10 +32,10 @@ local new_gotests_args = function(parallel)
   if string.len(gotests_template) > 0 then
     table.insert(args, "-template")
     table.insert(args, gotests_template)
-    if string.len(gotests_template_dir) > 0 then
-      table.insert(args, "-template_dir")
-      table.insert(args, gotests_template_dir)
-    end
+  end
+  if string.len(gotests_template_dir) > 0 then
+    table.insert(args, "-template_dir")
+    table.insert(args, gotests_template_dir)
   end
   return args
 end


### PR DESCRIPTION
In gotests, the `template` and `template_dir` parameters are two independent parameters. 
You can use 
`gotests -i -template testify -all xxxx`
 or 
`gotests -i -template_dir yourtemplatedirpath -all xxxx` 
These two are not strongly bound (since someone might have simply created a few tmpl templates to meet their own needs).

I have noticed that in go.nvim, there is a dependency relationship between these two parameters. So I made some adjustments.

This will not affect the current template users, but it can help those who have only set the template_dir, as it was not previously effective when only configuring `gotests_template_dir`.