### PR TITLE
issue-323 fix: check valid tags before overwriting gopls buildFlags

### DIFF
--- a/lua/go/gopls.lua
+++ b/lua/go/gopls.lua
@@ -296,7 +296,7 @@ M.setups = function()
   end
 
   local tags = get_build_flags()
-  if tags ~= '' then
+  if tags and tags ~= '' then
     setups.settings.gopls.buildFlags = { tags }
   end
 


### PR DESCRIPTION
Fixes related issue:
https://github.com/ray-x/go.nvim/issues/323