### PR TITLE
Ensure correct tools installation in goenv mode

### DIFF
--- a/lua/go/install.lua
+++ b/lua/go/install.lua
@@ -35,24 +35,29 @@ for tool, _ in pairs(url) do
 end
 
 local function is_installed(bin)
+  if utils.installed_tools[bin] then
+    return true
+  end
+
   local sep = utils.sep2()
   local ext = utils.ext()
 
+
   if utils.goenv_mode() then
     local cwd = vim.fn.getcwd()
-    local cmd = "cd " .. cwd .. " && goenv exec go env GOPATH"
-    local handle = io.popen(cmd)
-    local gopath = handle:read("*a")
-    handle:close()
-    gopath = gopath:gsub("%s+", "")
+    local cmd = "cd " .. cwd .. " && goenv which " .. bin .. " 2>&1"
 
-    if uv.fs_stat(gopath .. sep .. "bin" .. sep .. bin .. ext) then
+    local status = os.execute(cmd)
+
+    if status == 0 then
+      utils.installed_tools[bin] = true
       return true
     end
     return false
   end
 
   if vim.fn.executable(bin) == 1 then
+    utils.installed_tools[bin] = true
     return true
   end
 
@@ -61,6 +66,7 @@ local function is_installed(bin)
 
   for _, value in pairs(base_paths) do
     if uv.fs_stat(value .. DIR_SEP .. bin .. ext) then
+      utils.installed_tools[bin] = true
       return true
     end
   end

--- a/lua/go/utils.lua
+++ b/lua/go/utils.lua
@@ -910,7 +910,7 @@ end
 
 -- Returns true when host has goenv in path.
 util.goenv_mode = function()
-  local cmd = "goenv version > /dev/null 2>&1"
+  local cmd = "which goenv > /dev/null 2>&1"
   if is_windows then
     cmd = "where goenv >nul 2>nul"
   end

--- a/lua/go/utils.lua
+++ b/lua/go/utils.lua
@@ -292,7 +292,8 @@ util.log = function(...)
   end
 end
 
-util.trace = function(...) end
+util.trace = function(...)
+end
 
 local rhs_options = {}
 
@@ -910,15 +911,19 @@ end
 
 -- Returns true when host has goenv in path.
 util.goenv_mode = function()
-  local cmd = "which goenv > /dev/null 2>&1"
+  local cmd = "command -v goenv > /dev/null 2>&1"
+
   if is_windows then
     cmd = "where goenv >nul 2>nul"
+
+    local handle = io.popen(cmd)
+    local result = handle:close()
+
+    return result
   end
 
-  local handle = io.popen(cmd)
-  local result = handle:close()
-
-  return result
+  local status = os.execute(cmd)
+  return status == 0
 end
 
 return util

--- a/lua/go/utils.lua
+++ b/lua/go/utils.lua
@@ -909,19 +909,19 @@ util.remove_ansi_escape = function(str)
   return str
 end
 
--- Returns true when host has goenv in path.
+-- Keeps track of tools that are already installed.
+-- The keys are the names of tools and the values are booleans 
+-- indicating whether the tools is available or not.
+util.installed_tools = {}
+
+-- Check if host has goenv in path.
 util.goenv_mode = function()
-  local cmd = "command -v goenv > /dev/null 2>&1"
-
   if is_windows then
-    cmd = "where goenv >nul 2>nul"
-
-    local handle = io.popen(cmd)
-    local result = handle:close()
-
-    return result
+    -- always return false for Windows because goenv doesn't seem to be supported there.
+    return false
   end
 
+  local cmd = "command -v goenv > /dev/null 2>&1"
   local status = os.execute(cmd)
   return status == 0
 end

--- a/lua/go/utils.lua
+++ b/lua/go/utils.lua
@@ -47,6 +47,7 @@ function util.ext()
   end
   return ''
 end
+
 local function get_path_sep()
   if is_windows then
     return ';'
@@ -190,7 +191,7 @@ end
 
 util.map = function(modes, key, result, options)
   options =
-    util.merge({ noremap = true, silent = false, expr = false, nowait = false }, options or {})
+      util.merge({ noremap = true, silent = false, expr = false, nowait = false }, options or {})
   local buffer = options.buffer
   options.buffer = nil
 
@@ -446,7 +447,7 @@ end
 
 function util.relative_to_cwd(name)
   local rel = fn.isdirectory(name) == 0 and fn.fnamemodify(name, ':h:.')
-    or fn.fnamemodify(name, ':.')
+      or fn.fnamemodify(name, ':.')
   if rel == '.' then
     return '.'
   else
@@ -652,6 +653,7 @@ function util.get_active_buf()
 
   return result
 end
+
 -- for l:item in l:blist
 --     "skip unnamed buffers; also skip hidden buffers?
 --     if empty(l:item.name) || l:item.hidden
@@ -747,7 +749,7 @@ function util.uuid()
 end
 
 local lorem =
-  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum'
+'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum'
 function util.lorem()
   return lorem
 end
@@ -828,7 +830,6 @@ util.extract_filepath = function(msg, pkg_path)
   msg = msg or ''
   -- util.log(msg)
   --[[     or [[    findAllSubStr_test.go:234: Error inserting caseResult1: operation error DynamoDB: PutItem, exceeded maximum number of attempts]]
-
   -- or 'path/path2/filename.go:50:11: Error invaild
   -- or /home/ray/go/src/github/sample/app/driver.go:342 +0x19e5
   local ma = fn.matchlist(msg, [[\v\s*(\w+.+\.go):(\d+):]])
@@ -905,6 +906,19 @@ util.remove_ansi_escape = function(str)
   str = str:gsub(ansi_escape_pattern, '')
   str = str:gsub('\27%[[%d;]*%a', '')
   return str
+end
+
+-- Returns true when host has goenv in path.
+util.goenv_mode = function()
+  local cmd = "goenv version > /dev/null 2>&1"
+  if is_windows then
+    cmd = "where goenv >nul 2>nul"
+  end
+
+  local handle = io.popen(cmd)
+  local result = handle:close()
+
+  return result
 end
 
 return util

--- a/lua/tests/go_tags_spec.lua
+++ b/lua/tests/go_tags_spec.lua
@@ -6,6 +6,9 @@ local cur_dir = vim.fn.expand("%:p:h")
 -- local status = require("plenary.reload").reload_module("go.nvim")
 -- status = require("plenary.reload").reload_module("nvim-treesitter")
 
+-- time to wait for action to take effect
+local wait_time = 500
+
 -- local ulog = require('go.utils').log
 describe("should run gotags", function()
   local cmd
@@ -37,7 +40,7 @@ describe("should run gotags", function()
     local gotags = require("go.tags")
     gotags.add()
     -- enable the channel response
-    vim.wait(100, function()
+    vim.wait(wait_time, function()
     end)
     local fmt = vim.fn.join(vim.fn.readfile(name), "\n")
     -- ulog("tagged file: " .. fmt)
@@ -71,13 +74,13 @@ describe("should run gotags", function()
     local gotags = require("go.tags")
     gotags.rm('json')
     -- enable the channel response
-    vim.wait(100, function()
+    vim.wait(wait_time, function()
     end)
 
     -- format the code
     local gofmt = require("go.format")
     gofmt.gofmt()
-    vim.wait(100, function()
+    vim.wait(wait_time, function()
     end)
     local fmt = vim.fn.join(vim.fn.readfile(name), "\n")
     -- ulog("tagged file: " .. fmt)
@@ -111,12 +114,12 @@ describe("should run gotags", function()
     local gotags = require("go.tags")
     gotags.rm()
     -- enable the channel response
-    vim.wait(100, function()
+    vim.wait(wait_time, function()
     end)
 
     local gofmt = require("go.format")
     gofmt.gofmt()
-    vim.wait(100, function()
+    vim.wait(wait_time, function()
     end)
 
     local fmt = vim.fn.join(vim.fn.readfile(name), "\n")
@@ -152,12 +155,12 @@ describe("should run gotags", function()
     local gotags = require("go.tags")
     gotags.rm()
     -- enable the channel response
-    vim.wait(100, function()
+    vim.wait(wait_time, function()
     end)
 
     local gofmt = require("go.format")
     gofmt.gofmt()
-    vim.wait(100, function()
+    vim.wait(wait_time, function()
     end)
 
     local fmt = vim.fn.join(vim.fn.readfile(name), "\n")


### PR DESCRIPTION
Tools will be installed in the appropriated directory when [goenv](https://github.com/syndbg/goenv) manages GOPATH.

I tried to make it work on Mac, Linux (Ubuntu), ~and Windows but I have no way of testing it on Windows~ 😅 

goenv doesn't seem to be supported on Windows.
