### PR TITLE
fix(doc): add missing parameter documentation

### DIFF
--- a/doc/go.txt
+++ b/doc/go.txt
@@ -152,6 +152,7 @@ COMMANDS                                                     *go-nvim-commands*
         flags:
         -t coveragefile  load coverage data from coveragefile
 
+        -p       Coverage for current package only
         -r       Remove existing highlighting in current buffer.
         -R       Remove all existing highlighting.
         -t       Toggle display of highlighting.


### PR DESCRIPTION
Parameter `-p` was not documented for `:GoCoverage`