### PR TITLE
Migrate to new Treesitter query API

### DIFF
--- a/lua/go/snips.lua
+++ b/lua/go/snips.lua
@@ -141,7 +141,7 @@ local function set_query()
     return
   end
   query_is_set = true
-  vim.treesitter.set_query(
+  vim.treesitter.query.set(
     'go',
     'LuaSnip_Result',
     [[


### PR DESCRIPTION
vim.treesitter.set_query is deprecated. Using vim.treesitter.query.set instead.