### PR TITLE
adding support for *.gohtml files as per documentation.

### DIFF
--- a/ftdetect/filetype.vim
+++ b/ftdetect/filetype.vim
@@ -4,6 +4,7 @@ set cpo&vim
 au BufRead,BufNewFile *.go setfiletype go
 au BufRead,BufNewFile *.s setfiletype asm
 au BufRead,BufNewFile *.tmpl set filetype=gohtmltmpl
+au BufRead,BufNewFile *.gohtml set filetype=gohtmltmpl
 au BufRead,BufNewFile go.sum set filetype=gosum
 au BufRead,BufNewFile go.work.sum set filetype=gosum
 au BufRead,BufNewFile go.work set filetype=gowork


### PR DESCRIPTION
The documentation @ https://github.com/ray-x/go.nvim/blob/8a0498ee48a26f928b1dc1c02fb3d84d648a1c63/doc/go.txt#L90 indicates that there is html support for *.gohtml files but this doesn't seem to be the case.

It can be currently overridden in your NeoVim settings by running the following Lua code after setup:
```lua
vim.api.nvim_command('au BufRead,BufNewFile *.gohtml set filetype=gohtmltmpl')
```