### PR TITLE
change default `lsp_diag_virtual_text` prefix to nvim default

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,7 +775,7 @@ require('go').setup({
   lsp_diag_hdlr = true, -- hook lsp diag handler
   lsp_diag_underline = true,
   -- virtual text setup
-  lsp_diag_virtual_text = { space = 0, prefix = "" },
+  lsp_diag_virtual_text = { space = 0, prefix = '■' },
   lsp_diag_signs = true,
   lsp_diag_update_in_insert = false,
   lsp_document_formatting = true,

--- a/doc/go.txt
+++ b/doc/go.txt
@@ -390,6 +390,7 @@ You can setup go.nvim with following options:
   lsp_keymaps = true, -- true: apply default lsp keymaps
   lsp_codelens = true,
   lsp_diag_hdlr = true, -- hook lsp diag handler
+  lsp_diag_virtual_text = { space = 0, prefix = '■' }, -- lsp virtual text format
   lsp_inlay_hints = {
     enable = true,
 

--- a/lua/go.lua
+++ b/lua/go.lua
@@ -45,7 +45,7 @@ _GO_NVIM_CFG = {
   lsp_diag_hdlr = true, -- hook lsp diag handler
   lsp_diag_underline = true,
   -- virtual text setup
-  lsp_diag_virtual_text = { space = 0, prefix = '' },
+  lsp_diag_virtual_text = { space = 0, prefix = '■' },
   lsp_diag_signs = true,
   lsp_inlay_hints = {
     enable = true,


### PR DESCRIPTION
This pull request changes the default character for the prefix in a diagnostic virtual text line to the same one used in neovim by default ([see here](https://github.com/neovim/neovim/blob/8c9dab3e0d788d44c8a2fee83a6193f5955c814e/runtime/lua/vim/diagnostic.lua#L1065))

The existing character ("") used to work for me but has recently gone missing and does not render.
![image](https://github.com/ray-x/go.nvim/assets/37380474/f88d8a5f-3c52-436d-8261-bad4a4562b89)

If this change makes sense perhaps it would also make sense to change `parameter_hints_prefix` as it
(for me) similarly does not render. If you agree I can make the change.

Thanks again for the lovely plug in ❤️ . 
