### PR TITLE
fix(ui): replace obsolete nerd fonts from ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,7 +755,7 @@ require('go').setup({
   tag_options = 'json=omitempty', -- sets options sent to gomodifytags, i.e., json=omitempty
   gotests_template = "", -- sets gotests -template parameter (check gotests for details)
   gotests_template_dir = "", -- sets gotests -template_dir parameter (check gotests for details)
-  comment_placeholder = '' ,  -- comment_placeholder your cool placeholder e.g. ﳑ       
+  comment_placeholder = '' ,  -- comment_placeholder your cool placeholder e.g. 󰟓       
   icons = {breakpoint = '🧘', currentpos = '🏃'},  -- setup to `false` to disable icons setup
   verbose = false,  -- output loginf in messages
   lsp_cfg = false, -- true: use non-default gopls setup specified in go/lsp.lua
@@ -795,7 +795,7 @@ require('go').setup({
     -- default: false
     show_variable_name = true,
     -- prefix for parameter hints
-    parameter_hints_prefix = " ",
+    parameter_hints_prefix = "󰊕 ",
     show_parameter_hints = true,
     -- prefix for all the other hints (type, chaining)
     other_hints_prefix = "=> ",

--- a/doc/go.txt
+++ b/doc/go.txt
@@ -409,7 +409,7 @@ You can setup go.nvim with following options:
     show_variable_name = true,
 
     -- prefix for parameter hints
-    parameter_hints_prefix = " ",
+    parameter_hints_prefix = "󰊕 ",
     show_parameter_hints = true,
 
     -- prefix for all the other hints (type, chaining)

--- a/lua/go.lua
+++ b/lua/go.lua
@@ -65,7 +65,7 @@ _GO_NVIM_CFG = {
     show_variable_name = true,
 
     -- prefix for parameter hints
-    parameter_hints_prefix = ' ',
+    parameter_hints_prefix = '󰊕 ',
     show_parameter_hints = true,
 
     -- prefix for all the other hints (type, chaining)

--- a/lua/go/gotestsum.lua
+++ b/lua/go/gotestsum.lua
@@ -48,7 +48,7 @@ local show_panel = function()
   end
   if test_panel == nil or not test_panel:is_open() then
     test_panel = panel:new({
-      header = '    go test   ',
+      header = '  󰏖  go test   ',
       render = function(buf)
         -- log(test_result)
         return test_result

--- a/lua/go/package.lua
+++ b/lua/go/package.lua
@@ -130,7 +130,7 @@ local show_panel = function(result, pkg, rerender)
   log('create panel')
   if panel then
     local p = panel:new({
-      header = '    ' .. pkg_name .. '   ',
+      header = '  󰏖  ' .. pkg_name .. '   ',
       render = function(b)
         log('render for ', bufnr, b)
         -- log(debug.traceback())


### PR DESCRIPTION
Replace using [nerdfix](https://github.com/loichyan/nerdfix).

Nerdfont >= 3.0.0 dropped class name `nf-mdi-*`, replacing with new class name `nf-md-*`.
The new class name exists since nerdfont 2.3.0 so user with nerdfont >= 2.3.0 installed should be fine.

Refer https://github.com/ryanoasis/nerd-fonts/releases/tag/v3.0.0