### PR TITLE
fix: correct filetype assignments

### DIFF
--- a/ftdetect/filetype.vim
+++ b/ftdetect/filetype.vim
@@ -3,7 +3,8 @@ set cpo&vim
 
 au BufRead,BufNewFile *.go setfiletype go
 au BufRead,BufNewFile *.s setfiletype asm
-au BufRead,BufNewFile *.tmpl set filetype=gohtmltmpl
+au BufRead,BufNewFile *.tmpl set filetype=gotexttmpl
+au BufRead,BufNewFile *.gotext set filetype=gotexttmpl
 au BufRead,BufNewFile *.gohtml set filetype=gohtmltmpl
 au BufRead,BufNewFile go.sum set filetype=gosum
 au BufRead,BufNewFile go.work.sum set filetype=gosum


### PR DESCRIPTION
Docs say that `*.gotext` should be recognized as `gotexttmpl` but that is not the case.

I also changed `*.tmpl` to `gotexttmpl` since that is how I use it - not certain if that would be acceptable to everyone though.