### PR TITLE
Disable ts injections in import strings

### DIFF
--- a/after/queries/go/injections.scm
+++ b/after/queries/go/injections.scm
@@ -19,6 +19,7 @@
    (interpreted_string_literal)
    (raw_string_literal)
  ] @sql
+ (#not-has-ancestor? @sql import_declaration)
  (#match? @sql "(SELECT|select|INSERT|insert|UPDATE|update|DELETE|delete).+(FROM|from|INTO|into|VALUES|values|SET|set).*(WHERE|where|GROUP BY|group by)?")
  (#offset! @sql 0 1 0 -1))
 
@@ -29,6 +30,7 @@
   (interpreted_string_literal)
   (raw_string_literal)
  ] @sql
+ (#not-has-ancestor? @sql import_declaration)
  (#contains? @sql "-- sql" "--sql" "ADD CONSTRAINT" "ALTER TABLE" "ALTER COLUMN"
                   "DATABASE" "FOREIGN KEY" "GROUP BY" "HAVING" "CREATE INDEX" "INSERT INTO"
                   "NOT NULL" "PRIMARY KEY" "UPDATE SET" "TRUNCATE TABLE" "LEFT JOIN" "add constraint" "alter table" "alter column" "database" "foreign key" "group by" "having" "create index" "insert into"


### PR DESCRIPTION
Import paths like 'database/sql' are string literals and activate tree-sitter language injection for SQL. Adding a `#not-has-ancestor` predicate for `import_declaration` prevents this.

Example:

![image](https://github.com/ray-x/go.nvim/assets/4517909/c1730218-c84b-48e5-a39a-396a8cb6335f)
