### PR TITLE
Fix Incorrect Key for Virtual Text Spacing in Diagnostics Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,7 +783,7 @@ require('go').setup({
     hdlr = false, -- hook lsp diag handler and send diag to quickfix
     underline = true,
     -- virtual text setup
-    virtual_text = { space = 0, prefix = '■' },
+    virtual_text = { spacing = 0, prefix = '■' },
     signs = true,
     update_in_insert = false,
   },

--- a/doc/go.txt
+++ b/doc/go.txt
@@ -394,7 +394,7 @@ You can setup go.nvim with following options:
     hdlr = false, -- hook lsp diag handler and send diag to quickfix
     underline = true,
     -- virtual text setup
-    virtual_text = { space = 0, prefix = '■' },
+    virtual_text = { spacing = 0, prefix = '■' },
     signs = true,
     update_in_insert = false,
   },

--- a/lua/go.lua
+++ b/lua/go.lua
@@ -46,7 +46,7 @@ _GO_NVIM_CFG = {
     hdlr = false, -- hook diagnostic handler and send error to quickfix
     underline = true,
     -- virtual text setup
-    virtual_text = { space = 0, prefix = '■' },
+    virtual_text = { spacing = 0, prefix = '■' },
     update_in_insert = false,
     signs = true,
   },
@@ -54,7 +54,7 @@ _GO_NVIM_CFG = {
   -- lsp_diag_hdlr = true, -- hook lsp diag handler
   -- lsp_diag_underline = true,
   -- -- virtual text setup
-  -- lsp_diag_virtual_text = { space = 0, prefix = '■' },
+  -- lsp_diag_virtual_text = { spacing = 0, prefix = '■' },
   -- lsp_diag_signs = true,
   lsp_inlay_hints = {
     enable = true,


### PR DESCRIPTION
This PR corrects the key used to configure the virtual text spacing for diagnostics.

As per [Neovim's documentation](https://neovim.io/doc/user/diagnostic.html#diagnostic-api), the appropriate key for controlling the virtual text's spacing is `spacing`. However, the current configuration incorrectly uses `space`.

**Before**:
```lua
virtual_text = { space = 0, prefix = '■' },
```

**After**:
```lua
virtual_text = { spacing = 0, prefix = '■' },
```

It's worth noting that this change may not have a noticeable impact on functionality. This is because a `nil` spacing value might be interpreted similarly to a spacing value of 0. 