### PR TITLE
fixup: check for env variables based on go env

### DIFF
--- a/lua/go/asyncmake.lua
+++ b/lua/go/asyncmake.lua
@@ -7,7 +7,7 @@ local getopt = require('go.alt_getopt')
 
 local is_windows = util.is_windows()
 local is_git_shell = is_windows
-  and (vim.fn.exists('$SHELL') and vim.fn.expand('$SHELL'):find('bash.exe') ~= nil)
+    and (vim.fn.exists('$SHELL') and vim.fn.expand('$SHELL'):find('bash.exe') ~= nil)
 
 local function compile_efm()
   local efm = [[%-G#\ %.%#]]
@@ -322,7 +322,7 @@ M.runjob = function(cmd, runner, args, efm)
       end
       if next(errorlines) ~= nil and runner == 'golangci-lint' then
         efm =
-          [[level=%tarning\ msg="%m:\ [%f:%l:%c:\ %.%#]",level=%tarning\ msg="%m",level=%trror\ msg="%m:\ [%f:%l:%c:\ %.%#]",level=%trror\ msg="%m",%f:%l:%c:\ %m,%f:%l:\ %m,%f:%l\ %m]]
+        [[level=%tarning\ msg="%m:\ [%f:%l:%c:\ %.%#]",level=%tarning\ msg="%m",level=%trror\ msg="%m:\ [%f:%l:%c:\ %.%#]",level=%trror\ msg="%m",%f:%l:%c:\ %m,%f:%l:\ %m,%f:%l\ %m]]
       end
 
       sprite.on_close()
@@ -386,7 +386,9 @@ M.runjob = function(cmd, runner, args, efm)
         vim.notify(info .. ' failed', level)
       else
         vim.notify(info .. ' succeed', level)
-        vim.notify(table.concat(lines, '\n\r'), level)
+        if #lines > 0 then
+          vim.notify(table.concat(lines, '\n\r'), level)
+        end
       end
       failed = false
       _GO_NVIM_CFG.on_exit(event, data)

--- a/lua/go/coverage.lua
+++ b/lua/go/coverage.lua
@@ -327,7 +327,8 @@ M.run = function(...)
     else
       table.remove(args, 1)
       local test_coverage = M.read_cov(covfn)
-      vim.notify(string.format('total coverage: %d%%', test_coverage.total_covered / test_coverage.total_lines * 100))
+      vim.notify(string.format('total coverage: %d%%', test_coverage.total_covered / test_coverage.total_lines * 100),
+        vim.log.levels.INFO)
       return test_coverage
     end
     arg = select(2, ...)
@@ -430,15 +431,15 @@ M.run = function(...)
 
       vim.notify(
         'go coverage finished with message: '
-          .. vim.inspect(cmd)
-          .. 'error: '
-          .. vim.inspect(data)
-          .. '\n'
-          .. 'job '
-          .. tostring(job_id)
-          .. '\n'
-          .. 'ev '
-          .. event,
+        .. vim.inspect(cmd)
+        .. 'error: '
+        .. vim.inspect(data)
+        .. '\n'
+        .. 'job '
+        .. tostring(job_id)
+        .. '\n'
+        .. 'ev '
+        .. event,
         vim.log.levels.WARN
       )
     end,

--- a/lua/go/health.lua
+++ b/lua/go/health.lua
@@ -124,8 +124,7 @@ end
 
 
 -- check if GOBIN is in PATH
-local function path_check()
-  local gobin = vim.fn.systemlist('go env GOBIN')
+local function path_check(gobin)
   local path = os.getenv('PATH')
   if gobin == '' or vim.v.shell_error ~= 0 then
     util.error('GOBIN is not set')
@@ -139,11 +138,21 @@ local function path_check()
   return true
 end
 
+local function goenv()
+  local env = {}
+  local raw = vim.fn.system('go env')
+  for key, value in string.gmatch(raw, "([^=]+)='([^']*)'\n") do
+    env[key] = value
+  end
+  return env
+end
+
 local function env_check()
-  local envs = { 'GOROOT', 'GOBIN' }
+  local env = goenv()
+  local keys = { 'GOROOT', 'GOBIN' }
   local any_warn = false
-  for _, env in ipairs(envs) do
-    if vim.env[env] == nil then
+  for _, key in ipairs(keys) do
+    if env[key] == nil then
       info(string.format('%s is not set', env))
       any_warn = true
     else
@@ -155,7 +164,7 @@ local function env_check()
   else
     ok('All environment variables set')
   end
-  if not path_check() then
+  if not path_check(env["GOBIN"]) then
     warn('GOBIN is not in PATH')
   else
     ok('GOBIN is in PATH')

--- a/lua/go/health.lua
+++ b/lua/go/health.lua
@@ -130,7 +130,7 @@ local function path_check(gobin)
     util.error('GOBIN is not set')
     return false
   end
-  gobin = gobin[1] or 'notfound'
+  gobin = gobin or 'notfound'
   -- check GOBIN inside PATH
   if not vim.tbl_contains(vim.split(path, ':', { trimempty = true }), gobin) then
     return false
@@ -142,7 +142,7 @@ local function goenv()
   local env = {}
   local raw = vim.fn.system('go env')
   for key, value in string.gmatch(raw, "([^=]+)='([^']*)'\n") do
-    env[key] = value
+    env[key] = #value > 0 and value or nil
   end
   return env
 end
@@ -153,10 +153,10 @@ local function env_check()
   local any_warn = false
   for _, key in ipairs(keys) do
     if env[key] == nil then
-      info(string.format('%s is not set', env))
+      info(string.format('%s is not set', key))
       any_warn = true
     else
-      ok(string.format('%s is set', env))
+      ok(string.format('%s is set', key))
     end
   end
   if any_warn then


### PR DESCRIPTION
not all golang env specific variables are injected into vim.env, so check their presence based on go env instead