### PR TITLE
Updates to treesitter queries to support upstream changes

### DIFF
--- a/after/queries/go/locals.scm
+++ b/after/queries/go/locals.scm
@@ -1,15 +1,15 @@
 ; extends
 
-(var_spec) @scope
+(var_spec) @local.scope
 
 (field_declaration
-  name: (field_identifier) @definition.field)
+  name: (field_identifier) @local.definition.field)
 
 (method_spec
-  name: (field_identifier) @method.name
-  parameters: (parameter_list) @method.parameter_list) @interface.method.declaration
+  name: (field_identifier) @function.method.name
+  parameters: (parameter_list) @function.method.parameter_list) @local.interface.method.declaration
 
 (type_declaration
   (type_spec
-    name: (type_identifier) @name
-    type: [(struct_type) (interface_type)] @type)) @start
+    name: (type_identifier) @local.name
+    type: [(struct_type) (interface_type)] @local.type)) @local.start

--- a/lua/go/ts/utils.lua
+++ b/lua/go/ts/utils.lua
@@ -40,6 +40,7 @@ local function get_definitions(bufnr)
   -- Make sure the nodes are unique.
   local nodes_set = {}
   for _, loc in ipairs(local_nodes) do
+    loc = loc["local"]
     if loc.definition then
       locals.recurse_local_nodes(loc.definition, function(_, node, _, match)
         -- lua doesn't compare tables by value,


### PR DESCRIPTION
I believe this should fix #423

Full disclosure, I know absolutely nothing about treesitter/the scheme query definitions. I just read the docs a bit and tweaked stuff here until things stopped hemorrhaging errors 😆 

I imagine there should also be some updates to the queries defined [here](https://github.com/ray-x/go.nvim/blob/24d2fa373d55d9900cd4b502a88214dc17e6fab6/lua/go/ts/go.lua), but that's probably best left to someone with some actual knowledge on the subject.

For at least everything I do in my usual workflow, these commits stop any errors regarding 'local' indexing issues that I've been running into.