### PR TITLE
fix(doc): modify mismatched code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,14 +434,15 @@ generate method stubs for implementing an interface
 
 Usage:
 
-````
+```
 :GoImpl {receiver} {interface}
+```
 
 Also, you can put the cursor on the struct and run
 
-```vim
+```
 :GoImpl {interface}
-````
+```
 
 e.g:
 


### PR DESCRIPTION
Fixing markdown syntax errors in readme document