### PR TITLE
fix: specify buffer manually

### DIFF
--- a/lua/go/codelens.lua
+++ b/lua/go/codelens.lua
@@ -53,7 +53,9 @@ function M.refresh()
   if _GO_NVIM_CFG.lsp_codelens == true then
     local found = false
     if not found then
-      for _, lsp in pairs(vim.lsp.get_active_clients()) do
+      for _, lsp in pairs(vim.lsp.get_client {
+          bufnr = 0
+      }) do
         if lsp.name == 'gopls' then
           found = true
           break

--- a/lua/go/codelens.lua
+++ b/lua/go/codelens.lua
@@ -53,7 +53,7 @@ function M.refresh()
   if _GO_NVIM_CFG.lsp_codelens == true then
     local found = false
     if not found then
-      for _, lsp in pairs(vim.lsp.get_client {
+      for _, lsp in pairs(vim.lsp.get_clients {
           bufnr = 0
       }) do
         if lsp.name == 'gopls' then

--- a/lua/go/codelens.lua
+++ b/lua/go/codelens.lua
@@ -53,9 +53,7 @@ function M.refresh()
   if _GO_NVIM_CFG.lsp_codelens == true then
     local found = false
     if not found then
-      for _, lsp in pairs(vim.lsp.get_clients {
-          bufnr = 0
-      }) do
+      for _, lsp in pairs(vim.lsp.buf_get_clients(0)) do
         if lsp.name == 'gopls' then
           found = true
           break


### PR DESCRIPTION
in my case this line fixes: https://github.com/ray-x/go.nvim/issues/434

previously we tried to call codelense for current buffer using gopls instance for different ones. This happened cause fresh gopls is started for external dependencies.

Here I used https://neovim.io/doc/user/lsp.html#vim.lsp.get_clients() to get LSP for a specific buffer.