### PR TITLE
Fixes #451 inlay hint api change

### DIFF
--- a/lua/go/inlay.lua
+++ b/lua/go/inlay.lua
@@ -278,7 +278,7 @@ function M.toggle_inlay_hints()
   local bfnrstr = tostring(bufnr)
   if inlay_display then
     enabled[bfnrstr] = vim.lsp.inlay_hint.is_enabled(bufnr)
-    vim.lsp.inlay_hint.enable(not enabled[bfnrstr], {bufnr})
+    vim.lsp.inlay_hint.enable(not enabled[bfnrstr], {bufnr=bufnr})
   elseif enabled[bfnrstr] then
     M.disable_inlay_hints(true)
   else
@@ -291,7 +291,7 @@ function M.disable_inlay_hints(update, bufnr)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
   if inlay_display then
     -- disable inlay hints
-    vim.lsp.inlay_hint.enable(false, {bufnr})
+    vim.lsp.inlay_hint.enable(false, {bufnr=bufnr})
     enabled[tostring(bufnr)] = false
     return
   end
@@ -319,7 +319,7 @@ function M.set_inlay_hints()
   local filetime = fn.getftime(fname)
   if inlay_display then
     local wrap = utils.throttle(function()
-      vim.lsp.inlay_hint.enable(true, {bufnr})
+      vim.lsp.inlay_hint.enable(true, {bufnr=bufnr})
       should_update[fname] = filetime
     end, 300)
     return wrap()

--- a/lua/go/inlay.lua
+++ b/lua/go/inlay.lua
@@ -278,7 +278,7 @@ function M.toggle_inlay_hints()
   local bfnrstr = tostring(bufnr)
   if inlay_display then
     enabled[bfnrstr] = vim.lsp.inlay_hint.is_enabled(bufnr)
-    vim.lsp.inlay_hint.enable(bufnr, not enabled[bfnrstr])
+    vim.lsp.inlay_hint.enable(not enabled[bfnrstr], {bufnr})
   elseif enabled[bfnrstr] then
     M.disable_inlay_hints(true)
   else
@@ -291,7 +291,7 @@ function M.disable_inlay_hints(update, bufnr)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
   if inlay_display then
     -- disable inlay hints
-    vim.lsp.inlay_hint.enable(bufnr, false)
+    vim.lsp.inlay_hint.enable(false, {bufnr})
     enabled[tostring(bufnr)] = false
     return
   end
@@ -319,7 +319,7 @@ function M.set_inlay_hints()
   local filetime = fn.getftime(fname)
   if inlay_display then
     local wrap = utils.throttle(function()
-      vim.lsp.inlay_hint.enable(bufnr)
+      vim.lsp.inlay_hint.enable(true, {bufnr})
       should_update[fname] = filetime
     end, 300)
     return wrap()


### PR DESCRIPTION
Change the calls to inlay_hint.enable to arrange the parameters in the expected way.

Fixes #451 

this is the error this PR addresses:

```
vim.lsp.inlay_hint.enable(bufnr:number, enable:boolean) is deprecated, use vim.lsp.inlay_hint.enable(enable:boolean, filter:table) instead. :help
 deprecated
Feature was removed in Nvim 0.10-dev
```