### PR TITLE
Fix for inlay_hint.lua:383: enable: expected boolean, got table #456

### DIFF
--- a/lua/go/inlay.lua
+++ b/lua/go/inlay.lua
@@ -278,7 +278,7 @@ function M.toggle_inlay_hints()
   local bfnrstr = tostring(bufnr)
   if inlay_display then
     enabled[bfnrstr] = vim.lsp.inlay_hint.is_enabled(bufnr)
-    vim.lsp.inlay_hint.enable(not enabled[bfnrstr], {bufnr=bufnr})
+    vim.lsp.inlay_hint.enable(bufnr, not enabled[bfnrstr])
   elseif enabled[bfnrstr] then
     M.disable_inlay_hints(true)
   else
@@ -291,7 +291,7 @@ function M.disable_inlay_hints(update, bufnr)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
   if inlay_display then
     -- disable inlay hints
-    vim.lsp.inlay_hint.enable(false, {bufnr=bufnr})
+    vim.lsp.inlay_hint.enable(bufnr, false)
     enabled[tostring(bufnr)] = false
     return
   end
@@ -319,7 +319,7 @@ function M.set_inlay_hints()
   local filetime = fn.getftime(fname)
   if inlay_display then
     local wrap = utils.throttle(function()
-      vim.lsp.inlay_hint.enable(true, {bufnr=bufnr})
+      vim.lsp.inlay_hint.enable(bufnr, true)
       should_update[fname] = filetime
     end, 300)
     return wrap()


### PR DESCRIPTION
#456 

Fix for the inlay_hint.lua file.

The documentation said that the parameters need to be changed 
from:
`
enable({enable},{bufnr}) 
`
to:
`enable({bufnr}, {enable}) 
`
Also it only takes in the buffer number and **not** a table.
