### PR TITLE
fix: add back compatibility with neovim v0.9

### DIFF
--- a/lua/go.lua
+++ b/lua/go.lua
@@ -169,7 +169,7 @@ _GO_NVIM_CFG = {
 local function reset_tbl(tbl)
   for k, _ in pairs(tbl) do
     if type(tbl[k]) == 'table' then
-      if vim.islist(tbl[k]) then
+      if (vim.islist or vim.tbl_islist)(tbl[k]) then
         tbl[k] = {}
       else
         reset_tbl(tbl[k])


### PR DESCRIPTION
a recent commit utilizes `vim.islist` which is only available in neovim v0.10 which is still new and not necessarily widely available across all package managers or used yet. It's probably a good idea to at least support the previous version along with the current version.