### PR TITLE
fix: limit codelens refresh to current buffer

### DIFF
--- a/lua/go/codelens.lua
+++ b/lua/go/codelens.lua
@@ -53,7 +53,7 @@ function M.refresh()
     return
   end
   if _GO_NVIM_CFG.lsp_codelens == true then
-    vim.lsp.codelens.refresh()
+    vim.lsp.codelens.refresh({ bufnr = 0 })
   else
     log('refresh codelens')
     vim.lsp.codelens.clear()

--- a/lua/go/lsp.lua
+++ b/lua/go/lsp.lua
@@ -39,7 +39,7 @@ local on_attach = function(client, bufnr)
   end
 
   if _GO_NVIM_CFG.lsp_codelens then
-    vim.lsp.codelens.refresh()
+    vim.lsp.codelens.refresh({ bufnr = 0 })
   end
   local keymaps
   if _GO_NVIM_CFG.lsp_keymaps == true then


### PR DESCRIPTION
The behavior of `vim.lsp.codelens.refresh()` had been changed in https://github.com/neovim/neovim/pull/27253 to refresh all open buffers.

This changes the function calls to specify the current buffer to maintain the old behavior.

Fixes https://github.com/ray-x/go.nvim/issues/472.