### PR TITLE
Ignore `doc/tags`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+doc/tags


### PR DESCRIPTION
Thank you for these superb code action additions for golang! I use them regularly.

I use native vim package management in combination with git submodules. Every time I run `:helptags ALL` the only plugin I use that shows erroneous submodule files is go.nvim because a `doc/tags` file has been generated.

I think it is harmless to add this to the ignore list and you generally don't check these in as most plugin managers generate them for you.