### PR TITLE
fix: GoBuild cmd completion is not module-compatible

### DIFF
--- a/lua/go/list.lua
+++ b/lua/go/list.lua
@@ -1,14 +1,9 @@
 local M = {}
-function M.list(mod, args)
+function M.list(args)
   local cmd = {'go', 'list', '-json'}
-
-  local out
-  if mod == false then
-    table.insert(cmd, 1, 'GO111MODULE=off')
-  end
-
   vim.list_extend(cmd, args or {'.'})
-  out = vim.fn.systemlist(table.concat(cmd, ' '))
+
+  local out = vim.fn.systemlist(table.concat(cmd, ' '))
   if vim.v.shell_error ~= 0 then
     require('go.utils').warn('go list failed', vim.inspect(out))
     return false

--- a/lua/go/package.lua
+++ b/lua/go/package.lua
@@ -9,7 +9,7 @@ local pkgs = {}
 local complete = function(sep)
   log('complete', sep)
   sep = sep or '\n'
-  local ok, l = golist(false, { util.all_pkgs() })
+  local ok, l = golist { util.all_pkgs() }
   if not ok then
     log('Failed to find all packages for current module/project.')
     return
@@ -47,7 +47,7 @@ local complete = function(sep)
 end
 
 local all_pkgs = function()
-  local ok, l = golist(false, { util.all_pkgs() })
+  local ok, l = golist { util.all_pkgs() }
   if not ok then
     log('Failed to find all packages for current module/project.')
   end


### PR DESCRIPTION
Partially fixes #484

Right now, module-aware mode is consistently disabled in `:GoBuild` completions due to setting `GO111MODULE=off`, so completion does not work in the large majority of Go projects[^1].
Alternatively, the plugin could switch to using `GO111MODULE=auto` but, in my opinion, these global Go environment variables are better off remaining under the user's control.

This PR does _not_ address the duplication of completed entries, described in the referenced issue, since it is a whole separate problem from the one being addressed here.

[^1]: Since Go 1.16, module-aware mode is [enabled by default](https://go.dev/ref/mod#mod-commands). That version was released on 2021-02-16, which is over 3 years ago at the time of submitting this PR.