### PR TITLE
Improve command description

### DIFF
--- a/doc/go.txt
+++ b/doc/go.txt
@@ -302,7 +302,7 @@ COMMANDS                                                     *go-nvim-commands*
         Continue debug session, keymap `c`
 
 :GoCreateLaunch                                                     *:GoCreateLaunch*
-        Create alaunch.json
+        Create a sample launch.json configuration file
 
 :GoBreakToggle                                                     *:GoBreakToggle*
         Debugger breakpoint toggle


### PR DESCRIPTION
A space was missing, and I think a few extra word making it clearer that the file needs to be adapted and is a configuration file will help.