### PR TITLE
Add option to disable semantic highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,6 +765,7 @@ require('go').setup({
   comment_placeholder = '' ,  -- comment_placeholder your cool placeholder e.g. 󰟓       
   icons = {breakpoint = '🧘', currentpos = '🏃'},  -- setup to `false` to disable icons setup
   verbose = false,  -- output loginf in messages
+  lsp_semantic_highlights = true, -- use highlights from gopls
   lsp_cfg = false, -- true: use non-default gopls setup specified in go/lsp.lua
                    -- false: do nothing
                    -- if lsp_cfg is a table, merge table with with non-default gopls setup in go/lsp.lua, e.g.

--- a/lua/go.lua
+++ b/lua/go.lua
@@ -26,6 +26,7 @@ _GO_NVIM_CFG = {
   -- true: apply non-default gopls setup defined in go/gopls.lua
   -- if lsp_cfg is a table, merge table with with non-default gopls setup in go/gopls.lua, e.g.
   lsp_gofumpt = false, -- true: set default gofmt in gopls format to gofumpt
+  lsp_semantic_highlights = true, -- use highlights from gopls
   lsp_on_attach = nil, -- nil: use on_attach function defined in go/lsp.lua for gopls,
   --      when lsp_cfg is true
   -- if lsp_on_attach is a function: use this function as on_attach function for gopls,

--- a/lua/go/lsp.lua
+++ b/lua/go/lsp.lua
@@ -103,7 +103,7 @@ local on_attach = function(client, bufnr)
   if client.name == 'gopls' then
     local semantic = client.config.capabilities.textDocument.semanticTokens
     local provider = client.server_capabilities.semanticTokensProvider
-    if semantic then
+    if _GO_NVIM_CFG.lsp_semantic_highlights and semantic then
       client.server_capabilities.semanticTokensProvider =
         vim.tbl_deep_extend('force', provider or {}, {
           full = true,


### PR DESCRIPTION
This adds the option to disable the semantic token highlights coming from gopls. This is a popular option for people who are used to not having these highlights and prefer the default (eg. Treesitter) ones.