### PR TITLE
Enabling select test to run on floatterm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ localfailed: localtestsetup
 localtest: localtestsetup
 	nvim --headless --noplugin -u lua/tests/init.vim -c "PlenaryBustedDirectory lua/tests/ {minimal_init = 'lua/tests/init.vim'}"
 localtestfile: localtestsetup
-	nvim --headless --noplugin -u lua/tests/init.vim -c "PlenaryBustedFile lua/tests/go_comment_spec.lua"
+	nvim --headless --noplugin -u lua/tests/init.vim -c "PlenaryBustedFile lua/tests/go_test_spec.lua"
 lint:
 	luacheck lua/go
 
@@ -20,6 +20,9 @@ localtestsetup:
 
 	@test -d $(PACKER_DIR)/nvim-lspconfig ||\
 		git clone --depth 1 https://github.com/neovim/nvim-lspconfig $(PACKER_DIR)/nvim-lspconfig
+
+	@test -d $(PACKER_DIR)/guihua ||\
+		git clone --depth 1 https://github.com/ray-x/guihua.lua $(PACKER_DIR)/guihua
 
 	@test -d $(PACKER_DIR)/nvim-treesitter ||\
 		git clone --depth 1 https://github.com/nvim-treesitter/nvim-treesitter $(PACKER_DIR)/nvim-treesitter

--- a/lua/tests/go_test_spec.lua
+++ b/lua/tests/go_test_spec.lua
@@ -72,6 +72,90 @@ describe('should run func test', function()
       "-test.run='^\\QTest_branch\\E$'",
     }, cmd)
   end)
+  it('should test function on float term', function()
+    local path = 'coverage/branch_test.go' -- %:p:h ? %:p
+    require('go').setup({
+      trace = true,
+      lsp_cfg = true,
+      log_path = vim.fn.expand('$HOME') .. '/tmp/gonvim.log',
+      test_runner = 'go',
+    })
+    vim.cmd('cd ' .. godir)
+    vim.cmd("silent exe 'e " .. path .. "'")
+    vim.fn.setpos('.', { 0, 5, 11, 0 })
+    local expCmd = {}
+    require('go.term').run = function(tbl)
+      expCmd = tbl.cmd
+    end
+    require('go.gotest').test_func('-F')
+
+    eq({
+      'go',
+      'test',
+      './coverage',
+      "-test.run='^\\QTest_branch\\E$'",
+    }, expCmd)
+  end)
+  it('should test function selecting tests', function()
+    local path = 'coverage/branch_test.go' -- %:p:h ? %:p
+    require('go').setup({
+      trace = true,
+      lsp_cfg = true,
+      log_path = vim.fn.expand('$HOME') .. '/tmp/gonvim.log',
+      test_runner = 'go',
+    })
+    vim.cmd('cd ' .. godir)
+    vim.cmd("silent exe 'e " .. path .. "'")
+    vim.fn.setpos('.', { 0, 5, 11, 0 })
+    _GO_NVIM_CFG.go_select = function()
+      return function(_, _, func)
+        func('TestBranch', 2)
+      end
+    end
+    local expCmd = ""
+    local expArgs = {}
+    vim.lsp.buf.execute_command = function (tbl)
+      expCmd = tbl.command
+      expArgs = tbl.arguments
+    end
+    require('go.gotest').test_func('-s')
+
+    vim.wait(500)
+
+    eq('gopls.run_tests', expCmd)
+    eq({'TestBranch'}, expArgs[1].Tests)
+  end)
+  it('should test function on floating term selecting tests', function()
+    local path = 'coverage/branch_test.go' -- %:p:h ? %:p
+    require('go').setup({
+      trace = true,
+      lsp_cfg = true,
+      log_path = vim.fn.expand('$HOME') .. '/tmp/gonvim.log',
+      test_runner = 'go',
+    })
+    vim.cmd('cd ' .. godir)
+    vim.cmd("silent exe 'e " .. path .. "'")
+    vim.fn.setpos('.', { 0, 5, 11, 0 })
+    _GO_NVIM_CFG.go_select = function()
+      return function(_, _, func)
+        func('TestBranch', 2)
+      end
+    end
+    local expCmd = {}
+    require('go.term').run = function(tbl)
+      expCmd = tbl.cmd
+    end
+    require('go.gotest').test_func('-sF')
+
+    vim.wait(500)
+
+    eq({
+      'go',
+      'test',
+      './coverage',
+      "-test.run='^\\QTestBranch\\E$'",
+    }, expCmd)
+  end)
 end)
 
 describe('should run test file', function()


### PR DESCRIPTION
The float term is not working when running tests with the `-s` arg, here we check if the float term is enabled when selecting the tests, and run only the selected on the float term.