### PR TITLE
fix forcing test godebug on `GoDebug` without params

### DIFF
--- a/lua/go/dap.lua
+++ b/lua/go/dap.lua
@@ -474,7 +474,7 @@ M.run = function(...)
   log(testfunc)
 
   if testfunc then
-    if testfunc.name ~= 'main' then
+    if testfunc.name:lower():find('test') and vim.tbl_isempty(optarg) then
       optarg['t'] = true
     end
   end


### PR DESCRIPTION
The only way to trigger the .vscode/launch.json dropdown list was to be on a `func main` function, which is unlikely when you're trying to debug from a large Go project. go.nvim was assuming that `GoDebug` with no params, would always be on a `Test*` function, which was then causing the `elif cfg_exist` to never reach: https://github.com/gcollura/go.nvim/blob/18f782221a6a72840e9dcf4f5b13cbd5f2967c1d/lua/go/dap.lua?plain=1#L557

This PR checks a little more strictly that the user doesn't want to trigger a debug run on a "test", and it doesn't try to override the option passed by the user. For example it would set `optarg['t'] = true` even when another flag was passed.