### PR TITLE
Add dap_enrich_config to pass enrich_config to dap adapter config

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,10 @@ Here is a sample [launch.json](https://github.com/ray-x/go.nvim/blob/master/play
     dap_enrich_config = function(config, on_config)
         local final_config = vim.deepcopy(finalConfig)
         final_config.env['NEW_ENV_VAR'] = 'env-var-value'
+        -- load .env file for your project
+        local workspacefolder = vim.lsp.buf.list_workspace_folders()[1] or vim.fn.getcwd()
+        local envs_from_file = require('go.env').load_env(workspacefolder .. 'your_project_dot_env_file_name')
+        final_config = vim.tbl_extend("force", final_config, envs_from_file)
         on_config(final_config)
     end
   ```

--- a/README.md
+++ b/README.md
@@ -627,6 +627,15 @@ Here is a sample [launch.json](https://github.com/ray-x/go.nvim/blob/master/play
 ### Load Env file
 
 - GoEnv {filename} By default load .env file in current directory, if you want to load other file, use {filename} option
+- Alternatively, you can specify an `dap_enrich_config` function, to modify the selected launch.json configuration on the fly,
+  as suggested by https://github.com/mfussenegger/nvim-dap/discussions/548#discussioncomment-8778225:
+  ```lua
+    dap_enrich_config = function(config, on_config)
+        local final_config = vim.deepcopy(finalConfig)
+        final_config.env['NEW_ENV_VAR'] = 'env-var-value'
+        on_config(final_config)
+    end
+  ```
 
 ### Generate return value
 
@@ -852,6 +861,7 @@ require('go').setup({
   dap_port = 38697, -- can be set to a number, if set to -1 go.nvim will pick up a random port
   dap_timeout = 15, --  see dap option initialize_timeout_sec = 15,
   dap_retries = 20, -- see dap option max_retries
+  dap_enrich_config = nil, -- see dap option enrich_config
   build_tags = "tag1,tag2", -- set default build tags
   textobjects = true, -- enable default text objects through treesittter-text-objects
   test_runner = 'go', -- one of {`go`,  `dlv`, `ginkgo`, `gotestsum`}

--- a/lua/go.lua
+++ b/lua/go.lua
@@ -145,6 +145,7 @@ _GO_NVIM_CFG = {
   dap_debug_vt = { enabled = true, enabled_commands = true, all_frames = true }, -- bool|table put your dap-virtual-text setup here set to false to disable
   dap_port = 38697, -- can be set to a number or -1 so go.nvim will pickup a random port
   dap_timeout = 15, --  see dap option initialize_timeout_sec = 15,
+  dap_enrich_config = nil, -- see dap option enrich_config
   dap_retries = 20, -- see dap option max_retries
   build_tags = '', --- you can provide extra build tags for tests or debugger
   textobjects = true, -- treesitter binding for text objects

--- a/lua/go/dap.lua
+++ b/lua/go/dap.lua
@@ -386,7 +386,13 @@ M.run = function(...)
   }
   dap.adapters.go = function(callback, config)
     if config.request == 'attach' and config.mode == 'remote' and config.host then
-      callback({ type = 'server', host = config.host, port = config.port, options = con_options })
+      callback({
+        type = 'server',
+        host = config.host,
+        port = config.port,
+        options = con_options,
+        enrich_config = _GO_NVIM_CFG.dap_enrich_config,
+      })
       return
     end
     stdout = vim.loop.new_pipe(false)
@@ -443,7 +449,13 @@ M.run = function(...)
     stderr:read_start(onread)
 
     vim.defer_fn(function()
-      callback({ type = 'server', host = host, port = port, options = con_options })
+      callback({
+        type = 'server',
+        host = host,
+        port = port,
+        options = con_options,
+        enrich_config = _GO_NVIM_CFG.dap_enrich_config,
+      })
     end, 1000)
   end
 


### PR DESCRIPTION
DAP suggests passing an `enrich_config` function to the adapter configuration to allow "hydrating" the launch.json configuration in case it contains an `envFile`, eg. https://github.com/mfussenegger/nvim-dap/discussions/548#discussioncomment-8778225

It can also be useful to expose this function given that `dap.adapters.go` gets overwritten by `go.nvim`. https://github.com/mfussenegger/nvim-dap/blob/8517126e9323e346f6a99b3b594c5a940b914dcd/doc/dap.txt#L199-L220

If nil, the enrich_config function is ignored, so we're going to default to that: https://github.com/mfussenegger/nvim-dap/blob/8517126e9323e346f6a99b3b594c5a940b914dcd/lua/dap.lua#L458


The motivation for me is that calling `GoEnv` depending on which launch configuration I select is a bit cumbersome, especially when different configurations specify different envFiles.