### PR TITLE
fix(gopls): handle nil diagnostic config

### DIFF
--- a/lua/go/gopls.lua
+++ b/lua/go/gopls.lua
@@ -309,7 +309,7 @@ end
 local range_format = 'textDocument/rangeFormatting'
 local formatting = 'textDocument/formatting'
 M.setups = function()
-  local update_in_insert = _GO_NVIM_CFG.diagnostic.update_in_insert or false
+  local update_in_insert = _GO_NVIM_CFG.diagnostic and _GO_NVIM_CFG.diagnostic.update_in_insert or false
   local diagTrigger = update_in_insert and 'Edit' or 'Save'
   local diagDelay = update_in_insert and '1s' or '250ms'
   local setups = {


### PR DESCRIPTION
Problem:
Docs suggest settting diagnostic to false to set elsewhere in your config. This leads to an runtime error accessing it here

Solution:
Add a check to ensure that the diagnostic configuration is not false before accessing its properties.