### PR TITLE
feat: option to disable vim command creation

### DIFF
--- a/lua/go.lua
+++ b/lua/go.lua
@@ -6,6 +6,7 @@ local vfn = vim.fn
 -- Keep this in sync with doc/go.txt
 _GO_NVIM_CFG = {
   disable_defaults = false, -- true|false when true disable all default settings, user need to set all settings
+  disable_commands = {}, -- Vim commands to disable, e.g. `{'Gofmt', 'GoDoc'}`
   go = 'go', -- set to go1.18beta1 if necessary
   goimports = 'gopls', -- if set to 'gopls' will use gopls format, also goimports
   fillstruct = 'gopls',

--- a/lua/go/commands.lua
+++ b/lua/go/commands.lua
@@ -2,6 +2,10 @@ local vfn = vim.fn
 
 local utils = require('go.utils')
 local create_cmd = function(cmd, func, opt)
+  if _GO_NVIM_CFG.disable_commands and vim.tbl_contains(_GO_NVIM_CFG.disable_commands, cmd) then
+    return
+  end
+
   opt = vim.tbl_extend('force', { desc = 'go.nvim ' .. cmd }, opt or {})
   vim.api.nvim_create_user_command(cmd, func, opt)
 end


### PR DESCRIPTION
### Why this change?

In case the Vim command created by `go.nvim` clashes with another plugin's Vim command, there is no _great_ way today to work around that, it seems.

### What was changed?

Add ability to opt _out_ of command creation for specific `go.nvim` commands.

Example config:

```lua
opts = {
	disable_commands = { "GoFmt" }, -- disables go.nvim's :GoFmt command creation
}
```

### Notes

If you would rather see a `remap_commands` option, I added an alternative PR for that in https://github.com/ray-x/go.nvim/pull/548
