### PR TITLE
feat: option to remap (or disable) vim command creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,6 +767,7 @@ Configure from lua suggested, The default setup:
 require('go').setup({
 
   disable_defaults = false, -- true|false when true set false to all boolean settings and replace all tables
+  remap_commands = {}, -- Vim commands to remap or disable, e.g. `{ GoFmt = "GoFormat", GoDoc = false }`
   -- settings with {}; string will be set to ''. user need to setup ALL the settings
   -- It is import to set ALL values in your own config if set value to true otherwise the plugin may not work
   go='go', -- go command, can be go[default] or e.g. go1.18beta1

--- a/lua/go.lua
+++ b/lua/go.lua
@@ -6,6 +6,7 @@ local vfn = vim.fn
 -- Keep this in sync with doc/go.txt
 _GO_NVIM_CFG = {
   disable_defaults = false, -- true|false when true disable all default settings, user need to set all settings
+  remap_commands = {}, -- Vim commands to remap or disable, e.g. `{ GoFmt = "GoFormat", GoDoc = false }`
   go = 'go', -- set to go1.18beta1 if necessary
   goimports = 'gopls', -- if set to 'gopls' will use gopls format, also goimports
   fillstruct = 'gopls',

--- a/lua/go/commands.lua
+++ b/lua/go/commands.lua
@@ -2,6 +2,17 @@ local vfn = vim.fn
 
 local utils = require('go.utils')
 local create_cmd = function(cmd, func, opt)
+  if _GO_NVIM_CFG.remap_commands then
+    local remap = _GO_NVIM_CFG.remap_commands
+    if remap[cmd] ~= nil then
+      if type(remap[cmd]) == 'string' then
+        cmd = remap[cmd] -- remap
+      elseif type(remap[cmd]) == 'boolean' and remap[cmd] == false then
+        return -- disable
+      end
+    end
+  end
+
   opt = vim.tbl_extend('force', { desc = 'go.nvim ' .. cmd }, opt or {})
   vim.api.nvim_create_user_command(cmd, func, opt)
 end


### PR DESCRIPTION
### Why this change?

In case the Vim command created by `go.nvim` clashes with another plugin's Vim command, there is no _great_ way today to work around that, it seems.

### What was changed?

Add ability to opt _out_ of command creation for specific `go.nvim` commands, or remap to a different command.

Example config:

```lua
opts = {
	remap_commands = {
		GoFmt = "GoFormat", -- remaps :GoFmt to :GoFormat 
        GoDoc = false  -- disables go.nvim's :GoFmt command creation
	},
}
```

### Notes

If you would rather see a simple `disable_commands` option, I added an alternative PR for that in #547