### PR TITLE
fix(injections): make json injections work in nvim 0.10.0

### DIFF
--- a/queries/go/injections.scm
+++ b/queries/go/injections.scm
@@ -86,21 +86,30 @@
 
 (const_spec
   name: (identifier)
-  value: (expression_list (raw_string_literal) @injection.content
-   (#lua-match? @injection.content "^`[\n|\t| ]*\{.*\}[\n|\t| ]*`$")
-   (#offset! @injection.content 0 1 0 -1)
-   (#set! injection.language "json")))
+  value: (expression_list
+	   (raw_string_literal
+	     (raw_string_literal_content) @injection.content
+             (#lua-match? @injection.content "^[\n|\t| ]*\{.*\}[\n|\t| ]*$")
+             (#set! injection.language "json")
+	    )
+   ))
 
 (short_var_declaration
     left: (expression_list (identifier))
-    right: (expression_list (raw_string_literal) @injection.content)
-  (#lua-match? @injection.content "^`[\n|\t| ]*\{.*\}[\n|\t| ]*`$")
-  (#offset! @injection.content 0 1 0 -1)
-  (#set! injection.language "json"))
+    right: (expression_list
+             (raw_string_literal
+               (raw_string_literal_content) @injection.content
+               (#lua-match? @injection.content "^[\n|\t| ]*\{.*\}[\n|\t| ]*$")
+               (#set! injection.language "json"))
+               )
+    )
 
 (var_spec
   name: (identifier)
-  value: (expression_list (raw_string_literal) @injection.content
-   (#lua-match? @injection.content "^`[\n|\t| ]*\{.*\}[\n|\t| ]*`$")
-   (#offset! @injection.content 0 1 0 -1)
-   (#set! injection.language "json")))
+  value: (expression_list
+           (raw_string_literal
+             (raw_string_literal_content) @injection.content
+             (#lua-match? @injection.content "^[\n|\t| ]*\{.*\}[\n|\t| ]*$")
+             (#set! injection.language "json")
+             )
+   ))


### PR DESCRIPTION
Before, when using master only sql works:
![image](https://github.com/user-attachments/assets/38aab40b-e4c5-4a19-8900-199776708c35)

After, json works as well:
![image](https://github.com/user-attachments/assets/0712e8a3-cf85-4fc1-a5e8-1b181d78b22d)

Side note, I only tested this with neovim 0.10.4

Resolves https://github.com/ray-x/go.nvim/issues/551
