### PR TITLE
bugfix: correct type for gopls

### DIFF
--- a/lua/go/lsp.lua
+++ b/lua/go/lsp.lua
@@ -189,8 +189,8 @@ end
 function M.setup()
   local goplscfg = M.config()
   if vim.lsp.config then
-    vim.lsp.config('gppls', goplscfg)
-    vim.lsp.enable('gppls')
+    vim.lsp.config('gopls', goplscfg)
+    vim.lsp.enable('gopls')
   else
     local lspconfig = utils.load_plugin('nvim-lspconfig', 'lspconfig')
     if lspconfig == nil then


### PR DESCRIPTION
looks like in the latest updated the LSP name was accidentally changed to `gppls`, which now causes me to have 2 LSPs attached `gopls` and `gppls`

```
:LspInfo

- gppls (id: 2)
- gopls (id: 3)
```