### PR TITLE
fix: do not populate hints if disabled in opts

### DIFF
--- a/lua/go/gopls.lua
+++ b/lua/go/gopls.lua
@@ -510,7 +510,7 @@ M.setups = function()
     setups.settings.gopls.buildFlags = { tags }
   end
 
-  if has_nvim0_10 then
+  if has_nvim0_10 and _GO_NVIM_CFG.lsp_inlay_hints.enable then
     setups.settings.gopls = vim.tbl_deep_extend('keep', setups.settings.gopls, {
       hints = {
         assignVariableTypes = true,


### PR DESCRIPTION
Currently setting
```lua
      lsp_inlay_hints = {
        enable = false,
      },
```
in setup opts still has inlay hints enabled since gopls settings for hints are still populated. This PR does not populate if `enable` is explicitly set to false. 