### PR TITLE
fix: missing comma in lazy.nvim config in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ use 'nvim-treesitter/nvim-treesitter'
   opts = {
     -- lsp_keymaps = false,
     -- other options
-  }
+  },
   config = function(lp, opts)
     require("go").setup(opts)
     local format_sync_grp = vim.api.nvim_create_augroup("GoFormat", {})


### PR DESCRIPTION
Simple fix to a typo (missing comma) in the example `lazy.nvim` configuration.