### PR TITLE
feat(highlights.scm): make if err != nil blocks less emphasized

### DIFF
--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -1,0 +1,20 @@
+;; extends
+
+(if_statement
+  [
+   "if"
+  ] @comment
+  condition: (binary_expression
+    left: (identifier) @left_id (#eq? @left_id "err")
+    operator: "!="
+    right: (nil)
+  ) @comment
+  consequence: (block
+    (return_statement
+      (expression_list
+        (identifier) @ret_id (#eq? @ret_id "err")
+      )
+    ) @comment
+  )
+ (#set! "priority" 128)
+)


### PR DESCRIPTION
Here's something fun, It de-emphasizes if err != nil blocks. I started using this for my own config. Feel free to close this.

![image](https://github.com/user-attachments/assets/5dad4274-e9bc-411d-82e5-d6ce43c37dbb)
