### PR TITLE
docs: fix typo on Govulnckeck

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,7 +689,7 @@ if err != nil {
 
 ### goenum
 
-- Goenum {arguments} Run goenum on current project
+- GoEnum {arguments} Run goenum on current project
 
 ### gonew
 

--- a/doc/go.txt
+++ b/doc/go.txt
@@ -364,10 +364,10 @@ COMMANDS                                                     *go-nvim-commands*
 :GoGenReturn
         generate return values for current function
 
-:Govulncheck
+:GoVulnCheck
         run govulncheck on current project
 
-:Goenum
+:GoEnum
         run goenum on current file
 
 :GoNew {filename}

--- a/lua/go/commands.lua
+++ b/lua/go/commands.lua
@@ -535,7 +535,7 @@ return {
       nargs = '*',
     })
 
-    create_cmd('Govulnckeck', function(opts)
+    create_cmd('GoVulnCheck', function(opts)
       require('go.govulncheck').run(opts.fargs)
     end, { nargs = '*' })
     create_cmd('GoEnum', function(opts)


### PR DESCRIPTION
Fixing typo on `Govulncheck` to `GoVulnCheck`.