### PR TITLE
fix: resolve double prompt and non-functional gorename fallback

### DIFF
--- a/lua/go/rename.lua
+++ b/lua/go/rename.lua
@@ -15,18 +15,19 @@ end
 
 local run = function(to_identifier, ...)
   require('go.install').install(gorename)
-  local fname = vfn.expand('%:p') -- %:p:h ? %:p
-
-  local old_identifier = vfn.expand('<cword>')
-
-  local prompt = vfn.printf("GoRename '%s' to (may take a while) :", old_identifier)
-  to_identifier = to_identifier or vfn.input(prompt, old_identifier)
-  local byte_offset = vfn.wordcount().cursor_bytes
-
   local client = require('go.lsp').client()
   if client then
     -- TODO check gopls?
     return lsprename()
   end
+  local fname = vfn.expand('%:p')
+  local old_identifier = vfn.expand('<cword>')
+  local prompt = vfn.printf("GoRename '%s' to (may take a while) :", old_identifier)
+  to_identifier = to_identifier or vfn.input(prompt, old_identifier)
+
+  local byte_offset = vfn.wordcount().cursor_bytes
+  local cmd = string.format('%s -offset %s:#%d -to %s', gorename, fname, byte_offset, to_identifier)
+
+  utils.run(cmd)
 end
 return { run = run, lsprename = lsprename }


### PR DESCRIPTION
This PR fixes a UX issue where we're being prompted twice for the new identifier name when performing a rename operation with an active LSP client.

**Problem**
The current implementation shows a prompt to get the new identifier name, and then checks if an LSP client is available. If a client exists, it calls lsprename() which shows its own prompt, resulting in being asked twice for the same input.
**Solution**
Check for the LSP client availability before prompting. This ensures we only see one prompt:

_If LSP client is available_: Use lsprename() directly (with its built-in prompt)
_If no LSP client_: Show prompt and proceed with gorename fallback

_Tests for go_fillstruct were already failing before my changes_

Fixes #586 