### PR TITLE
Fix `:GoModTidy` and probably others

### DIFF
--- a/lua/go/gopls.lua
+++ b/lua/go/gopls.lua
@@ -112,6 +112,7 @@ end
 for _, gopls_cmd in ipairs(gopls_cmds) do
   local gopls_cmd_name = string.sub(gopls_cmd, #'gopls.' + 1)
   cmds[gopls_cmd_name] = function(arg, callback)
+    arg = arg or {}
     -- get gopls client
     log(arg)
 


### PR DESCRIPTION
`:GoModTidy` is broken and throws the following error:

```
Error executing Lua callback: /home/account/.local/share/nvim/lazy/go.nvim/lua/go/gopls.lua:140: attempt to index local 'arg' (a nil value)
stack traceback:
        /home/account/.local/share/nvim/lazy/go.nvim/lua/go/gopls.lua:140: in function 'tidy'
        /home/account/.local/share/nvim/lazy/go.nvim/lua/go/gopls.lua:275: in function 'tidy'
        .../account/.local/share/nvim/lazy/go.nvim/lua/go/commands.lua:508: in function <.../account/.local/share/nvim/lazy/go.nvim/lua/go/commands.lua:507>
```

The problem comes from `cmds.tidy()` being called with no args:
https://github.com/ray-x/go.nvim/blob/eb92453bc049c156290ed402f90f74090aa86363/lua/go/gopls.lua#L274-L276

But the `cmds` functions all try to access the first arg without a nil check:
https://github.com/ray-x/go.nvim/blob/eb92453bc049c156290ed402f90f74090aa86363/lua/go/gopls.lua#L139-L149

Went for the simple fix of setting `arg` to an empty table if nil.