### PR TITLE
fix: shadowed variable causes error

### DIFF
--- a/lua/go/health.lua
+++ b/lua/go/health.lua
@@ -183,8 +183,8 @@ local function plugin_check()
   end
 
   -- check if treesitter-go is installed
-  local ok = pcall(vim.treesitter.language.inspect, 'go')
-  if not ok then
+  local tsok = pcall(vim.treesitter.language.inspect, 'go')
+  if not tsok then
     warn('treesitter-go is not installed, Please install go treesitter parser')
   else
     ok('treesitter-go is installed')


### PR DESCRIPTION
This PR fixes an issue where the local `ok` shadows the global assignment on line 15 which caused this error to always appear in healthchecks:
```
- ❌ ERROR Failed to run healthcheck for "go" plugin. Exception:
  ...user/.local/share/nvim/lazy/go.nvim/lua/go/health.lua:190: attempt to call local 'ok' (a boolean value)
```