### PR TITLE
fix: codelens.enable() nil error and GoListImports crash on empty result

### DIFF
--- a/lua/go/codelens.lua
+++ b/lua/go/codelens.lua
@@ -56,7 +56,7 @@ function M.refresh()
     return
   end
   if _GO_NVIM_CFG.lsp_codelens == true then
-    vim.lsp.codelens.enable(true, { bufnr = 0 })
+    vim.lsp.codelens.refresh({ bufnr = 0 })
   else
     log('refresh codelens')
     vim.lsp.codelens.clear(gopls.id, 0)

--- a/lua/go/commands.lua
+++ b/lua/go/commands.lua
@@ -521,6 +521,11 @@ return {
     create_cmd('GoListImports', function(_)
       local lines = require('go.gopls').list_imports().PackageImports or {}
 
+      if #lines == 0 then
+        vim.notify('GoListImports: no imports found', vim.log.levels.INFO)
+        return
+      end
+
       local close_events = { 'CursorMoved', 'CursorMovedI', 'BufHidden', 'InsertCharPre' }
       local config = {
         close_events = close_events,


### PR DESCRIPTION
Two independent bug fixes for Neovim 0.11.x compatibility and a spurious error in `GoListImports`.

### Bug 1: `BufWritePre` error — `attempt to call field 'enable' (a nil value)`

When `lsp_codelens = true`, saving any `.go` file triggers:
```
Error executing lua callback: ...go/codelens.lua:59: attempt to call field 'enable' (a nil value)
```

`vim.lsp.codelens.enable()` does not exist in Neovim 0.11.x.
The available API is: `refresh`, `clear`, `run`, `get`, `display`, `save`.

Commit `c8a356b` introduced this regression by replacing the working:

```lua
vim.lsp.codelens.refresh({ bufnr = 0 })
```

with:

```lua
vim.lsp.codelens.enable(true, { bufnr = 0 })
```

This PR reverts to the working `refresh()` call.

### Bug 2: `GoListImports` spurious error on files with no imports

When gopls returns an empty import list, the code fell through to `vim.lsp.util.open_floating_preview()` with `height = 0`, producing a spurious error. An early return with an `INFO` notification is added instead.

---

## Changes

| File | Change |
|---|---|
| `lua/go/codelens.lua` | Replace `vim.lsp.codelens.enable()` with `vim.lsp.codelens.refresh({ bufnr = 0 })` |
| `lua/go/commands.lua` | Guard `GoListImports` against empty result before opening floating preview |

---

## Reproduction Steps

**Bug 1:** Set `lsp_codelens = true`, open any `.go` file, save it → error fires on `BufWritePre`:
```
Error executing lua callback: ...go/codelens.lua:59: attempt to call field 'enable' (a nil value)
```

**Bug 2:** Run `:GoListImports` on a file with no imports → spurious floating window error.